### PR TITLE
[#151393894] Feature remove client from match

### DIFF
--- a/netcode.c
+++ b/netcode.c
@@ -6139,6 +6139,16 @@ void test_replay_protection()
     }
 }
 
+void match_test_helper(netcode_server_t * server)
+{
+    // Very basic test for checking if each match only has 2 or less clients connected.
+    skillz_match_t * m;
+    for( m = server->skillz_matches; m != NULL; m = ( skillz_match_t * ) ( m->hh.next ) )
+    {
+        check( m->num_clients_in_match <= server->max_clients_per_match );
+    }
+}
+
 static uint8_t private_key[NETCODE_KEY_BYTES] = { 0x60, 0x6a, 0xbe, 0x6e, 0xc9, 0x19, 0x10, 0xea, 
                                                   0x9a, 0x65, 0x62, 0xf6, 0x6f, 0x2b, 0x30, 0xe4, 
                                                   0x43, 0x71, 0xd6, 0x2c, 0xd1, 0x99, 0x27, 0x26,
@@ -6247,13 +6257,7 @@ void test_client_server_connect()
             netcode_server_free_packet( server, packet );
         }
 
-        // Very basic test for checking if each match only has 2 or less clients connected.
-        skillz_match_t * m;
-        for( m = server->skillz_matches; m != NULL; m = ( skillz_match_t * ) ( m->hh.next ) )
-        {
-            check( m->num_clients_in_match <= server->max_clients_per_match );
-        }
-
+        match_test_helper(server);
         skillz_match_t * match;
         if ( client_num_packets_received >= 10 && server_num_packets_received >= 10 )
         {
@@ -6586,13 +6590,7 @@ void test_client_server_multiple_clients()
         
         netcode_network_simulator_reset( network_simulator );
 
-        // Very basic test for checking if each match only has 2 or less clients connected.
-        // TODO:  Move to seperate test, can possibly use quit a bit from this test?
-        skillz_match_t * m;
-        for( m = server->skillz_matches; m != NULL; m = ( skillz_match_t * ) ( m->hh.next ) )
-        {
-        check( m->num_clients_in_match <= server->max_clients_per_match );
-        }
+        match_test_helper( server );
 
         for ( j = 0; j < max_clients[i]; ++j )
         {

--- a/netcode.c
+++ b/netcode.c
@@ -6245,11 +6245,30 @@ void test_client_server_connect()
             netcode_server_free_packet( server, packet );
         }
 
+        // Very basic test for checking if each match only has 2 or less clients connected.
+        skillz_match_t * m;
+        for( m = server->skillz_matches; m != NULL; m = ( skillz_match_t * ) ( m->hh.next ) )
+        {
+            check( m->num_clients_in_match <= server->max_clients_per_match );
+        }
+
+        skillz_match_t * match;
         if ( client_num_packets_received >= 10 && server_num_packets_received >= 10 )
         {
             if ( netcode_server_client_connected( server, 0 ) )
             {
+                // Skillz test for match purge.
+                HASH_FIND_INT( server->skillz_matches,
+                               &( server->skillz_match_id[0] ),
+                               match);
+                check( match != NULL );
+
                 netcode_server_disconnect_client( server, 0 );
+
+                HASH_FIND_INT( server->skillz_matches,
+                               &( server->skillz_match_id[0] ),
+                               match );
+                check( match == NULL );
             }
         }
 
@@ -6260,14 +6279,6 @@ void test_client_server_connect()
     }
 
     check( client_num_packets_received >= 10 && server_num_packets_received >= 10 );
-
-    // Very basic test for checking if each match only has 2 or less clients connected.
-    // TODO:  Move to seperate test, can possibly use quit a bit from this test?
-    skillz_match_t * m;
-    for( m = server->skillz_matches; m != NULL; m = ( skillz_match_t * ) ( m->hh.next ) )
-    {
-        check( m->num_clients_in_match <= server->max_clients_per_match );
-    }
 
     netcode_server_destroy( server );
 

--- a/netcode.c
+++ b/netcode.c
@@ -6709,11 +6709,29 @@ void test_client_server_multiple_servers()
             netcode_server_free_packet( server, packet );
         }
 
+        // Very basic test for checking if each match only has 2 or less clients connected.
+        skillz_match_t * m;
+        for( m = server->skillz_matches; m != NULL; m = ( skillz_match_t * ) ( m->hh.next ) )
+        {
+            check( m->num_clients_in_match <= server->max_clients_per_match );
+        }
+
         if ( client_num_packets_received >= 10 && server_num_packets_received >= 10 )
         {
             if ( netcode_server_client_connected( server, 0 ) )
             {
+                // Skillz test for match purge.
+                HASH_FIND_INT( server->skillz_matches,
+                               &( server->skillz_match_id[0] ),
+                               match);
+                check( match != NULL );
+
                 netcode_server_disconnect_client( server, 0 );
+
+                HASH_FIND_INT( server->skillz_matches,
+                               &( server->skillz_match_id[0] ),
+                               match);
+                check( match == NULL );
             }
         }
 

--- a/netcode.c
+++ b/netcode.c
@@ -6257,7 +6257,7 @@ void test_client_server_connect()
             netcode_server_free_packet( server, packet );
         }
 
-        check_num_clients_in_matches(server)
+        check_num_clients_in_matches(server);
 
         skillz_match_t * match;
         if ( client_num_packets_received >= 10 && server_num_packets_received >= 10 )
@@ -6591,7 +6591,7 @@ void test_client_server_multiple_clients()
         
         netcode_network_simulator_reset( network_simulator );
 
-        check_num_clients_in_matches(server)
+        check_num_clients_in_matches(server);
 
         for ( j = 0; j < max_clients[i]; ++j )
         {
@@ -6710,7 +6710,7 @@ void test_client_server_multiple_servers()
             netcode_server_free_packet( server, packet );
         }
 
-        check_num_clients_in_matches(server)
+        check_num_clients_in_matches(server);
 
         skillz_match_t * match;
         if ( client_num_packets_received >= 10 && server_num_packets_received >= 10 )

--- a/netcode.c
+++ b/netcode.c
@@ -3921,7 +3921,7 @@ void netcode_server_disconnect_all_clients( struct netcode_server_t * server )
  */
 void skillz_clear_matches( struct netcode_server_t * server )
 {
-    skillz_match_t * current_match, * tmp;
+    skillz_match_t * current_match = NULL, * tmp = NULL;
 
     HASH_ITER( hh, server->skillz_matches, current_match, tmp )
     {

--- a/netcode.c
+++ b/netcode.c
@@ -6716,6 +6716,7 @@ void test_client_server_multiple_servers()
             check( m->num_clients_in_match <= server->max_clients_per_match );
         }
 
+        skillz_match_t * match;
         if ( client_num_packets_received >= 10 && server_num_packets_received >= 10 )
         {
             if ( netcode_server_client_connected( server, 0 ) )

--- a/netcode.c
+++ b/netcode.c
@@ -6139,7 +6139,7 @@ void test_replay_protection()
     }
 }
 
-void check_num_clients_in_matches(netcode_server_t * server)
+void check_num_clients_in_matches(struct netcode_server_t * server)
 {
     // Very basic test for checking if each match only has 2 or less clients connected.
     skillz_match_t * m;

--- a/netcode.c
+++ b/netcode.c
@@ -6139,7 +6139,7 @@ void test_replay_protection()
     }
 }
 
-void match_test_helper(netcode_server_t * server)
+void check_num_clients_in_matches(netcode_server_t * server)
 {
     // Very basic test for checking if each match only has 2 or less clients connected.
     skillz_match_t * m;
@@ -6257,7 +6257,8 @@ void test_client_server_connect()
             netcode_server_free_packet( server, packet );
         }
 
-        match_test_helper(server);
+        check_num_clients_in_matches(server)
+
         skillz_match_t * match;
         if ( client_num_packets_received >= 10 && server_num_packets_received >= 10 )
         {
@@ -6590,7 +6591,7 @@ void test_client_server_multiple_clients()
         
         netcode_network_simulator_reset( network_simulator );
 
-        match_test_helper( server );
+        check_num_clients_in_matches(server)
 
         for ( j = 0; j < max_clients[i]; ++j )
         {
@@ -6709,12 +6710,7 @@ void test_client_server_multiple_servers()
             netcode_server_free_packet( server, packet );
         }
 
-        // Very basic test for checking if each match only has 2 or less clients connected.
-        skillz_match_t * m;
-        for( m = server->skillz_matches; m != NULL; m = ( skillz_match_t * ) ( m->hh.next ) )
-        {
-            check( m->num_clients_in_match <= server->max_clients_per_match );
-        }
+        check_num_clients_in_matches(server)
 
         skillz_match_t * match;
         if ( client_num_packets_received >= 10 && server_num_packets_received >= 10 )

--- a/netcode.c
+++ b/netcode.c
@@ -4205,16 +4205,16 @@ void netcode_server_connect_client( struct netcode_server_t * server,
     char address_string[NETCODE_MAX_ADDRESS_STRING_LENGTH];
 
     /* TODO: try to find a way to deliver match id. */
-    int testId = 0;
+    int test_id = 0;
     if( server->num_connected_clients >= 3 )
     {
-        testId = 222;
+        test_id = 222;
     }
     else
     {
-        testId = 111;
+        test_id = 111;
     }
-    if ( !skillz_add_client_to_match( server, testId, client_id, client_index ) )
+    if ( !skillz_add_client_to_match( server, test_id, client_id, client_index ) )
     {
         netcode_printf( NETCODE_LOG_LEVEL_ERROR, "failed to add client %d to match %d\n",
                         client_id, 0);

--- a/netcode.c
+++ b/netcode.c
@@ -3491,13 +3491,13 @@ struct netcode_server_t
     int running;
     int max_clients;
     int num_connected_clients;
-    int max_clients_per_match;											/* Max clients per match */
+    int max_clients_per_match;
     uint64_t global_sequence;
     uint8_t private_key[NETCODE_KEY_BYTES];
     uint64_t challenge_sequence;
     uint8_t challenge_key[NETCODE_KEY_BYTES];
-    skillz_match_t * skillz_matches;									/* Matches hash table */
-    int skillz_match_id[NETCODE_MAX_CLIENTS];							/* Index using client_index, much like client_id */
+    skillz_match_t * skillz_matches;
+    int skillz_match_id[NETCODE_MAX_CLIENTS];
     int client_connected[NETCODE_MAX_CLIENTS];
     int client_timeout[NETCODE_MAX_CLIENTS];
     int client_loopback[NETCODE_MAX_CLIENTS];
@@ -3769,10 +3769,9 @@ void skillz_print_all_matches( struct netcode_server_t * server )
     skillz_match_t * match;
 
     netcode_printf( NETCODE_LOG_LEVEL_INFO, "\n\nPrinting the matches and their clients.\n" );
-    int i;
     for( match = server->skillz_matches; match != NULL; match = ( skillz_match_t * )( match->hh.next ) )
     {
-        for( i = 0; i < match->num_clients_in_match; ++i)
+        for( int i = 0; i < match->num_clients_in_match; ++i)
         {
             netcode_printf( NETCODE_LOG_LEVEL_INFO, "match id: %d client id: %d clients in match: %d\n",
                     match->skillz_match_id, match->clients_in_match[i], match->num_clients_in_match );
@@ -3821,7 +3820,6 @@ void netcode_server_disconnect_client_internal( struct netcode_server_t * server
     netcode_assert( client_index < server->max_clients );
     netcode_assert( server->client_connected[client_index] );
     netcode_assert( !server->client_loopback[client_index] );
-    //netcode_assert( server->skillz_matches );
 
     netcode_printf( NETCODE_LOG_LEVEL_INFO, "server disconnected client %d\n", client_index );
 
@@ -4206,12 +4204,16 @@ void netcode_server_connect_client( struct netcode_server_t * server,
 
     char address_string[NETCODE_MAX_ADDRESS_STRING_LENGTH];
 
-    /* TODO: try to find a way to deliver match itd. */
+    /* TODO: try to find a way to deliver match id. */
     int testId = 0;
     if( server->num_connected_clients >= 3 )
+    {
         testId = 222;
+    }
     else
+    {
         testId = 111;
+    }
     if ( !skillz_add_client_to_match( server, testId, client_id, client_index ) )
     {
         netcode_printf( NETCODE_LOG_LEVEL_ERROR, "failed to add client %d to match %d\n",

--- a/netcode.h
+++ b/netcode.h
@@ -99,7 +99,6 @@ extern "C" {
   **/
 
 #define SKILLZ_MAX_CLIENTS_PER_MATCH 2
-#define SKILLZ_MAX_MATCHES ( (int) (NETCODE_MAX_CLIENTS) / ( 2 ) )
 
 // SKILLZ_TOURNAMENT_T
 typedef struct skillz_match_t

--- a/netcode.h
+++ b/netcode.h
@@ -99,6 +99,7 @@ extern "C" {
   **/
 
 #define SKILLZ_MAX_CLIENTS_PER_MATCH 2
+#define SKILLZ_MAX_MATCHES ( (int) (NETCODE_MAX_CLIENTS) / ( 2 ) )
 
 // SKILLZ_TOURNAMENT_T
 typedef struct skillz_match_t


### PR DESCRIPTION
Upon a disconnect clients are removed from a match, and the match is destroyed.  The client who was in the match with the disconnected client currently remains connected to the server.  Tests added to confirm that the memory is freed and the match no longer exists on the server.  

I kept the methods for indexing match_ids to client as closely as I could to the way netcode.io does it.

Included in the code are test match_id values, which will be replaced when changes to the connect packets are made.

Naming conventions for added skillz code is also solidified.

If you would like to test this functionality yourself I would create a server and create 4 clients and disconnect them randomly.

@IRog  @thePhilGuy @kkaminski  please review