### PR TITLE
[#151394226] Feature match id in packets

### DIFF
--- a/client.c
+++ b/client.c
@@ -78,10 +78,15 @@ int main( int argc, char ** argv )
     uint64_t client_id = 0;
     netcode_random_bytes( (uint8_t*) &client_id, 8 );
     printf( "client id is %.16" PRIx64 "\n", client_id );
+    printf( "client id is %" PRIu64 "\n", client_id );
+
+    uint64_t skillz_match_id = 0;
+    netcode_random_bytes( (uint8_t*) &skillz_match_id, 8 );
+    printf( "client is joining %" PRIu64 "\n", skillz_match_id );
 
     uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
 
-    if ( netcode_generate_connect_token( 1, &server_address, CONNECT_TOKEN_EXPIRY, CONNECT_TOKEN_TIMEOUT, client_id, PROTOCOL_ID, 0, private_key, connect_token ) != NETCODE_OK )
+    if ( netcode_generate_connect_token( 1, &server_address, CONNECT_TOKEN_EXPIRY, CONNECT_TOKEN_TIMEOUT, client_id, skillz_match_id, PROTOCOL_ID, 0, private_key, connect_token ) != NETCODE_OK )
     {
         printf( "error: failed to generate connect token\n" );
         return 1;

--- a/client.c
+++ b/client.c
@@ -78,7 +78,6 @@ int main( int argc, char ** argv )
     uint64_t client_id = 0;
     netcode_random_bytes( (uint8_t*) &client_id, 8 );
     printf( "client id is %.16" PRIx64 "\n", client_id );
-    printf( "client id is %" PRIu64 "\n", client_id );
 
     uint64_t skillz_match_id = 0;
     netcode_random_bytes( (uint8_t*) &skillz_match_id, 8 );

--- a/netcode.c
+++ b/netcode.c
@@ -6824,13 +6824,6 @@ void test_client_server_multiple_servers()
             netcode_server_free_packet( server, packet );
         }
 
-        // Very basic test for checking if each match only has 2 or less clients connected.
-        skillz_match_t * m;
-        for( m = server->skillz_matches; m != NULL; m = ( skillz_match_t * ) ( m->hh.next ) )
-        {
-            check( m->num_clients_in_match <= server->max_clients_per_match );
-        }
-
         skillz_match_t * match;
         if ( client_num_packets_received >= 10 && server_num_packets_received >= 10 )
         {

--- a/netcode.c
+++ b/netcode.c
@@ -3814,7 +3814,7 @@ int skillz_match_disconnect( struct netcode_server_t * server, int client_index 
         return 0;
     }
 
-    HASH_DEL( server->skillz_matches, match );
+    HASH_DELETE( hh, server->skillz_matches, match );
     // TODO: maybe check the match to see if one user is still connected, then disconnect them?
     free( match );
 
@@ -8158,15 +8158,15 @@ void test_skillz_only_two_clients_per_match_with_three_attempting()
         server->client_id[i] = i;
     }
 
-    uint64_t match_id = 0;
-    netcode_random_bytes( (uint8_t*) &match_id, 8 );
+    uint64_t match_id = 111;
     for(int i = 0; i < num_clients; ++i )
     {
         skillz_add_client_to_match( server, match_id, server->client_id[i], i );
     }
 
     skillz_match_t * match = NULL;
-    HASH_FIND_INT( server->skillz_matches, &match_id, match  );
+    HASH_FIND( hh, server->skillz_matches, &match_id, sizeof(uint64_t), match  );
+    check( match != NULL );
     check( match->num_clients_in_match == num_clients - 1 );
 
     for( int i = 0; i < num_clients; ++i )
@@ -8182,139 +8182,150 @@ void test_skillz_only_two_clients_per_match_with_three_attempting()
     free( clients );
 }
 
-//// This test will need massive changes when we introduce removing matches based on disconnect time.
-//void test_skillz_disconnect_frees_one_match_then_the_other_with_four_clients()
-//{
-//    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
-//
-//    network_simulator->latency_milliseconds = 250;
-//    network_simulator->jitter_milliseconds = 250;
-//    network_simulator->packet_loss_percent = 5;
-//    network_simulator->duplicate_packet_percent = 10;
-//
-//    double time = 0.0;
-//    double delta_time = 1.0 / 10.0;
-//
-//    int num_clients = 4;
-//
-//    struct netcode_server_t * server = netcode_server_create_internal("[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
-//    check( server );
-//    netcode_server_start( server, num_clients );
-//
-//    struct netcode_client_t ** clients = (struct netcode_client_t **) malloc( sizeof( struct netcode_client_t* ) * num_clients );
-//    check(clients);
-//
-//    uint64_t token_sequence = 0;
-//
-//    //  Creating and connecting clients.
-//    for( int i = 0; i < num_clients; ++i )
-//    {
-//        char client_address[NETCODE_MAX_ADDRESS_STRING_LENGTH];
-//        sprintf( client_address, "[::]:%d", 50000 + i );
-//
-//        *(clients + i) = netcode_client_create_internal( client_address, time, network_simulator, NULL, NULL, NULL );
-//
-//
-//        check( clients[i] );
-//
-//        uint64_t client_id = i;
-//        netcode_random_bytes( (uint8_t*) &client_id, 8 );
-//
-//        NETCODE_CONST char * server_address = "[::1]:40000";
-//
-//        uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
-//
-//        check( netcode_generate_connect_token( 1,
-//                                               &server_address,
-//                                               TEST_CONNECT_TOKEN_EXPIRY,
-//                                               TEST_TIMEOUT_SECONDS,
-//                                               client_id,
-//                                               TEST_PROTOCOL_ID,
-//                                               token_sequence++,
-//                                               private_key,
-//                                               connect_token) );
-//
-//        netcode_client_connect( clients[i], connect_token );
-//    }
-//
-//    // Connect the four clients.
-//
-//    while( 1 )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        for ( int j = 0; j < num_clients; ++j)
-//        {
-//            netcode_client_update( clients[j], time );
-//        }
-//
-//        netcode_server_update( server, time );
-//
-//        int num_connected_clients = 0;
-//
-//        for( int j = 0; j < num_clients; ++j )
-//        {
-//            if( netcode_client_state( clients[j] ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-//                break;
-//
-//            if( netcode_client_state( clients[j] ) == NETCODE_CLIENT_STATE_CONNECTED )
-//                num_connected_clients++;
-//        }
-//
-//        if ( num_connected_clients == num_clients )
-//            break;
-//
-//        time += delta_time;
-//    }
-//
-//    check( netcode_server_num_connected_clients( server ) == num_clients );
-//
-//    for( int j = 0; j < num_clients; ++j)
-//    {
-//        check( netcode_client_state( clients[j] ) == NETCODE_CLIENT_STATE_CONNECTED );
-//        check( netcode_server_client_connected( server, j ) == 1 );
-//    }
-//
-//    skillz_match_t * match;
-//    int match1_id = 111;
-//    int match2_id = 222;
-//
-//    // See if match1 exists, disconnect client one, then check if the match is gone while the
-//    // other exists.
-//    HASH_FIND_INT( server->skillz_matches, &match1_id, match );
-//    check( match->skillz_match_id == match1_id );
-//
-//    netcode_server_disconnect_client( server, 0 );
-//
-//    HASH_FIND_INT( server->skillz_matches, &match1_id, match );
-//    check( match == NULL);
-//
-//    // See if match2 exists, disconnect client three, then check if both of the matches are gone.
-//    HASH_FIND_INT( server->skillz_matches, &match2_id, match );
-//    check( match->skillz_match_id == match2_id );
-//
-//    netcode_server_disconnect_client(server, 2);
-//
-//    HASH_FIND_INT( server->skillz_matches, &match2_id, match );
-//    check( match == NULL);
-//
-//
-//    // Cleanup
-//    netcode_server_disconnect_client( server, 1 );
-//    netcode_server_disconnect_client( server, 3 );
-//    for( int i = 0; i < num_clients; ++i )
-//    {
-//        netcode_client_destroy( clients[i] );
-//    }
-//
-//    netcode_server_stop( server );
-//    netcode_server_destroy( server );
-//
-//    netcode_network_simulator_destroy( network_simulator );
-//
-//    free( clients );
-//
-//}
+// This test will need massive changes when we introduce removing matches based on disconnect time.
+void test_skillz_disconnect_frees_one_match_then_the_other_with_four_clients()
+{
+    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
+
+    network_simulator->latency_milliseconds = 250;
+    network_simulator->jitter_milliseconds = 250;
+    network_simulator->packet_loss_percent = 5;
+    network_simulator->duplicate_packet_percent = 10;
+
+    double time = 0.0;
+    double delta_time = 1.0 / 10.0;
+
+    int num_clients = 4;
+
+    struct netcode_server_t * server = netcode_server_create_internal("[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
+    check( server );
+    netcode_server_start( server, num_clients );
+
+    struct netcode_client_t ** clients = (struct netcode_client_t **) malloc( sizeof( struct netcode_client_t* ) * num_clients );
+    check(clients);
+
+    uint64_t token_sequence = 0;
+
+    //  Creating and connecting clients.
+    for( int i = 0; i < num_clients; ++i )
+    {
+        char client_address[NETCODE_MAX_ADDRESS_STRING_LENGTH];
+        sprintf( client_address, "[::]:%d", 50000 + i );
+
+        *(clients + i) = netcode_client_create_internal( client_address, time, network_simulator, NULL, NULL, NULL );
+
+
+        check( clients[i] );
+
+        uint64_t client_id = i;
+        netcode_random_bytes( (uint8_t*) &client_id, 8 );
+
+        NETCODE_CONST char * server_address = "[::1]:40000";
+
+        uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+
+        uint64_t mid = 0;
+        if( i < 1)
+        {
+            mid = 111;
+        }
+        else
+        {
+            mid = 222;
+        }
+
+        check( netcode_generate_connect_token( 1,
+                                               &server_address,
+                                               TEST_CONNECT_TOKEN_EXPIRY,
+                                               TEST_TIMEOUT_SECONDS,
+                                               client_id,
+                                               mid,
+                                               TEST_PROTOCOL_ID,
+                                               token_sequence++,
+                                               private_key,
+                                               connect_token) );
+
+        netcode_client_connect( clients[i], connect_token );
+    }
+
+    // Connect the four clients.
+
+    while( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        for ( int j = 0; j < num_clients; ++j)
+        {
+            netcode_client_update( clients[j], time );
+        }
+
+        netcode_server_update( server, time );
+
+        int num_connected_clients = 0;
+
+        for( int j = 0; j < num_clients; ++j )
+        {
+            if( netcode_client_state( clients[j] ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+                break;
+
+            if( netcode_client_state( clients[j] ) == NETCODE_CLIENT_STATE_CONNECTED )
+                num_connected_clients++;
+        }
+
+        if ( num_connected_clients == num_clients )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_server_num_connected_clients( server ) == num_clients );
+
+    for( int j = 0; j < num_clients; ++j)
+    {
+        check( netcode_client_state( clients[j] ) == NETCODE_CLIENT_STATE_CONNECTED );
+        check( netcode_server_client_connected( server, j ) == 1 );
+    }
+
+    skillz_match_t * match;
+    uint64_t match1_id = 111;
+    uint64_t match2_id = 222;
+
+    // See if match1 exists, disconnect client one, then check if the match is gone while the
+    // other exists.
+    HASH_FIND( hh, server->skillz_matches, &match1_id, sizeof(uint64_t), match );
+    check( match->skillz_match_id == match1_id );
+
+    netcode_server_disconnect_client( server, 0 );
+
+    HASH_FIND( hh, server->skillz_matches, &match1_id, sizeof(uint64_t), match );
+    check( match == NULL);
+
+    // See if match2 exists, disconnect client three, then check if both of the matches are gone.
+    HASH_FIND( hh, server->skillz_matches, &match2_id, sizeof(uint64_t), match );
+    check( match->skillz_match_id == match2_id );
+
+    netcode_server_disconnect_client(server, 2);
+
+    HASH_FIND( hh, server->skillz_matches, &match2_id, sizeof(uint64_t), match );
+    check( match == NULL);
+
+
+    // Cleanup
+    netcode_server_disconnect_client( server, 1 );
+    netcode_server_disconnect_client( server, 3 );
+    for( int i = 0; i < num_clients; ++i )
+    {
+        netcode_client_destroy( clients[i] );
+    }
+
+    netcode_server_stop( server );
+    netcode_server_destroy( server );
+
+    netcode_network_simulator_destroy( network_simulator );
+
+    free( clients );
+
+}
 
 
 #define RUN_TEST( test_function )                                           \
@@ -8360,8 +8371,8 @@ void netcode_test()
         RUN_TEST( test_disable_timeout );
         RUN_TEST( test_loopback );
         RUN_TEST( test_skillz_add_two_clients_to_match );
-        //RUN_TEST( test_skillz_only_two_clients_per_match_with_three_attempting );
-        //RUN_TEST( test_skillz_disconnect_frees_one_match_then_the_other_with_four_clients );
+        RUN_TEST( test_skillz_only_two_clients_per_match_with_three_attempting );
+        RUN_TEST( test_skillz_disconnect_frees_one_match_then_the_other_with_four_clients );
     }
 }
 

--- a/netcode.c
+++ b/netcode.c
@@ -7941,7 +7941,7 @@ void test_skillz_add_two_clients_to_match()
 
     uint64_t token_sequence = 0;
 
-    // Client things.
+    // Create and connect a client.
     for( int i = 0; i < num_clients; ++i )
     {
         char client_address[NETCODE_MAX_ADDRESS_STRING_LENGTH];

--- a/netcode.c
+++ b/netcode.c
@@ -6245,11 +6245,30 @@ void test_client_server_connect()
             netcode_server_free_packet( server, packet );
         }
 
+        // Very basic test for checking if each match only has 2 or less clients connected.
+        skillz_match_t * m;
+        for( m = server->skillz_matches; m != NULL; m = ( skillz_match_t * ) ( m->hh.next ) )
+        {
+            check( m->num_clients_in_match <= server->max_clients_per_match );
+        }
+
+        skillz_match_t * match;
         if ( client_num_packets_received >= 10 && server_num_packets_received >= 10 )
         {
             if ( netcode_server_client_connected( server, 0 ) )
             {
+                // Skillz test for match purge.
+                HASH_FIND_INT( server->skillz_matches,
+                               &( server->skillz_match_id[0] ),
+                               match);
+                check( match != NULL );
+
                 netcode_server_disconnect_client( server, 0 );
+
+                HASH_FIND_INT( server->skillz_matches,
+                               &( server->skillz_match_id[0] ),
+                               match );
+                check( match == NULL );
             }
         }
 
@@ -6260,14 +6279,6 @@ void test_client_server_connect()
     }
 
     check( client_num_packets_received >= 10 && server_num_packets_received >= 10 );
-
-    // Very basic test for checking if each match only has 2 or less clients connected.
-    // TODO:  Move to seperate test, can possibly use quit a bit from this test?
-    skillz_match_t * m;
-    for( m = server->skillz_matches; m != NULL; m = ( skillz_match_t * ) ( m->hh.next ) )
-    {
-        check( m->num_clients_in_match <= server->max_clients_per_match );
-    }
 
     netcode_server_destroy( server );
 

--- a/netcode.c
+++ b/netcode.c
@@ -7947,7 +7947,7 @@ void test_skillz_add_two_clients_to_match()
         char client_address[NETCODE_MAX_ADDRESS_STRING_LENGTH];
         sprintf( client_address, "[::]:%d", 50000 + i );
 
-        *(clients + i) = netcode_client_create_internal( client_address, time, network_simulator, NULL, NULL, NULL );
+        clients[i] = netcode_client_create_internal( client_address, time, network_simulator, NULL, NULL, NULL );
 
 
         check( clients[i] );
@@ -8021,9 +8021,6 @@ void test_skillz_add_two_clients_to_match()
     for( int i = 0; i < num_clients; ++i )
     {
         netcode_server_disconnect_client( server, i );
-    }
-    for( int i = 0; i < num_clients; ++i )
-    {
         netcode_client_destroy( clients[i] );
     }
 
@@ -8091,7 +8088,7 @@ void test_skillz_only_two_clients_per_match_with_three_attempting()
     free( clients );
 }
 
-// This test will need massive changes when we introduce removing matches based on dc time.
+// This test will need massive changes when we introduce removing matches based on disconnect time.
 void test_skillz_disconnect_frees_one_match_then_the_other_with_four_clients()
 {
     struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );

--- a/netcode.c
+++ b/netcode.c
@@ -6709,11 +6709,29 @@ void test_client_server_multiple_servers()
             netcode_server_free_packet( server, packet );
         }
 
+        // Very basic test for checking if each match only has 2 or less clients connected.
+        skillz_match_t * m;
+        for( m = server->skillz_matches; m != NULL; m = ( skillz_match_t * ) ( m->hh.next ) )
+        {
+            check( m->num_clients_in_match <= server->max_clients_per_match );
+        }
+
         if ( client_num_packets_received >= 10 && server_num_packets_received >= 10 )
         {
             if ( netcode_server_client_connected( server, 0 ) )
             {
+                // Skillz test for match purge.
+                HASH_FIND_INT( server->skillz_matches,
+                               &( server->skillz_match_id[0] ),
+                               match);
+                check( match != NULL );
+
                 netcode_server_disconnect_client( server, 0 );
+
+                HASH_FIND_INT( server->skillz_matches,
+                               &( server->skillz_match_id[0] ),
+                               match);
+                check( match == NULL );
             }
         }
 

--- a/netcode.c
+++ b/netcode.c
@@ -6305,8 +6305,10 @@ void test_skillz_add_two_clients_to_match()
 
     struct netcode_server_t * server = netcode_server_create_internal("[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
     check( server );
+    netcode_server_start( server, num_clients );
 
     struct netcode_client_t ** clients = (struct netcode_client_t **) malloc( sizeof( struct netcode_client_t* ) * num_clients );
+    check(clients);
 
     uint64_t token_sequence = 0;
 
@@ -6317,6 +6319,7 @@ void test_skillz_add_two_clients_to_match()
         sprintf( client_address, "[::]:%d", 50000 + i );
 
         *(clients + i) = netcode_client_create_internal( client_address, time, network_simulator, NULL, NULL, NULL );
+
 
         check( clients[i] );
 
@@ -6361,8 +6364,11 @@ void test_skillz_add_two_clients_to_match()
                 break;
 
             if( netcode_client_state( clients[j] ) == NETCODE_CLIENT_STATE_CONNECTED )
-                break;
+                num_connected_clients++;
         }
+
+        if ( num_connected_clients == num_clients )
+            break;
 
         time += delta_time;
     }
@@ -6375,90 +6381,10 @@ void test_skillz_add_two_clients_to_match()
         check( netcode_server_client_connected( server, j ) == 1 );
     }
 
-    // This is the packet stuff that needs to be done so that the match stuff gets triggered.
+    check( server->skillz_matches->num_clients_in_match == num_clients );
 
-    //int * server_num_packets_received = (int *) malloc( sizeof(int) * 2 );
-    //int * client_num_packets_received = (int *) malloc( sizeof(int) * 2 );
-
-    //uint8_t packet_data[NETCODE_MAX_PACKET_SIZE];
-    //for( int i = 0; i < NETCODE_MAX_PACKET_SIZE; ++i )
-    //    packet_data[i] = (uint8_t) i;
-
-    //while ( 1 )
-    //{
-    //    netcode_network_simulator_update( network_simulator, time );
-
-    //    netcode_client_update( client1, time );
-    //    netcode_client_update( client2, time );
-
-    //    netcode_server_update( server, time );
-
-    //    netcode_client_send_packet( client1, packet_data, NETCODE_MAX_PACKET_SIZE );
-    //    netcode_server_send_packet( server, 0, packet_data, NETCODE_MAX_PACKET_SIZE );
-
-    //    netcode_client_send_packet( client2, packet_data, NETCODE_MAX_PACKET_SIZE );
-    //    netcode_server_send_packet( server, 1, packet_data, NETCODE_MAX_PACKET_SIZE );
-
-    //    for( int j = 0; i < num_clients; ++j )
-    //    {
-    //        while ( 1 )
-    //        {
-    //            int packet_bytes;
-    //            uint64_t packet_sequence;
-    //            uint8_t * packet = netcode_client_receive_packet( clients[j], &packet_bytes, &packet_sequence );
-    //            if( !packet )
-    //                break;
-    //            (void) packet_sequence;
-    //            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
-    //            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
-    //            client_num_packets_received[j]++;
-    //            netcode_client_free_packet( clients[j], packet );
-    //        }
-    //    }
-
-    //    for( int j = 0; j < num_clients; ++j )
-    //    {
-    //        while( 1 )
-    //        {
-    //            int packet_bytes;
-    //            uint64_t packet_sequence;
-    //            void * packet = netcode_server_receive_packet( server, j, &packet_bytes, &packet_sequence );
-    //            if( !packet )
-    //                break;
-    //            (void) packet_sequence;
-    //            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
-    //            netcode_assert( memcpy( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
-    //            server_num_packets_received[j]++;
-    //            netcode_server_free_packet( server, packet );
-    //        }
-    //    }
-
-    //    int num_clients_ready = 0;
-
-    //    for( int j = 0; j < num_clients; ++j )
-    //    {
-    //        if( client_num_packets_received[j] >= 1 && server_num_packets_received[j] >= 1 )
-    //        {
-    //            num_clients_ready++;
-    //        }
-    //    }
-
-    //    check( num_clients_ready == num_clients );
-
-    //    // ADD THE MATCH STUFF HERE.
-    //    printf("HELLO");
-
-    //    for( int j = 0; j < num_clients; ++j )
-    //    {
-    //        if( netcode_client_state( clients[j] ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-    //            break;
-    //    }
-
-    //    time += delta_time;
-    //}
-
-    //free( server_num_packets_received );
-    //free( client_num_packets_received );
+    for( int i = 0; i < num_clients; ++i )
+        netcode_server_disconnect_client( server, i );
 
     for( int i = 0; i < num_clients; ++i )
         free( clients[i] );

--- a/netcode.c
+++ b/netcode.c
@@ -6716,6 +6716,7 @@ void test_client_server_multiple_servers()
             check( m->num_clients_in_match <= server->max_clients_per_match );
         }
 
+        skillz_match_t * match;
         if ( client_num_packets_received >= 10 && server_num_packets_received >= 10 )
         {
             if ( netcode_server_client_connected( server, 0 ) )

--- a/netcode.c
+++ b/netcode.c
@@ -8261,6 +8261,7 @@ void netcode_test()
         RUN_TEST( test_loopback );
         RUN_TEST( test_skillz_add_two_clients_to_match );
         RUN_TEST( test_skillz_only_two_clients_per_match_with_three_attempting );
+        RUN_TEST( test_skillz_disconnect_frees_one_match_then_the_other_with_four_clients );
     }
 }
 

--- a/netcode.c
+++ b/netcode.c
@@ -6289,127 +6289,6 @@ void test_client_server_connect()
     netcode_network_simulator_destroy( network_simulator );
 }
 
-void test_skillz_add_two_clients_to_match()
-{
-    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
-
-    network_simulator->latency_milliseconds = 250;
-    network_simulator->jitter_milliseconds = 250;
-    network_simulator->packet_loss_percent = 5;
-    network_simulator->duplicate_packet_percent = 10;
-
-    double time = 0.0;
-    double delta_time = 1.0 / 10.0;
-
-    int num_clients = 2;
-
-    struct netcode_server_t * server = netcode_server_create_internal("[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
-    check( server );
-    netcode_server_start( server, num_clients );
-
-    struct netcode_client_t ** clients = (struct netcode_client_t **) malloc( sizeof( struct netcode_client_t* ) * num_clients );
-    check(clients);
-
-    uint64_t token_sequence = 0;
-
-    // Client things.
-    for( int i = 0; i < num_clients; ++i )
-    {
-        char client_address[NETCODE_MAX_ADDRESS_STRING_LENGTH];
-        sprintf( client_address, "[::]:%d", 50000 + i );
-
-        *(clients + i) = netcode_client_create_internal( client_address, time, network_simulator, NULL, NULL, NULL );
-
-
-        check( clients[i] );
-
-        uint64_t client_id = i;
-        netcode_random_bytes( (uint8_t*) &client_id, 8 );
-
-        NETCODE_CONST char * server_address = "[::1]:40000";
-
-        uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
-
-        check( netcode_generate_connect_token( 1,
-                                               &server_address,
-                                               TEST_CONNECT_TOKEN_EXPIRY,
-                                               TEST_TIMEOUT_SECONDS,
-                                               client_id,
-                                               TEST_PROTOCOL_ID,
-                                               token_sequence++,
-                                               private_key,
-                                               connect_token) );
-
-        netcode_client_connect( clients[i], connect_token );
-    }
-
-    // Connect the two clients.
-
-    while( 1 )
-    {
-        netcode_network_simulator_update( network_simulator, time );
-
-        for ( int j = 0; j < num_clients; ++j)
-        {
-            netcode_client_update( clients[j], time );
-        }
-
-        netcode_server_update( server, time );
-
-        int num_connected_clients = 0;
-
-        for( int j = 0; j < num_clients; ++j )
-        {
-            if( netcode_client_state( clients[j] ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-                break;
-
-            if( netcode_client_state( clients[j] ) == NETCODE_CLIENT_STATE_CONNECTED )
-                num_connected_clients++;
-        }
-
-        if ( num_connected_clients == num_clients )
-            break;
-
-        time += delta_time;
-    }
-
-    check( netcode_server_num_connected_clients( server ) == num_clients );
-
-    for( int j = 0; j < num_clients; ++j)
-    {
-        check( netcode_client_state( clients[j] ) == NETCODE_CLIENT_STATE_CONNECTED );
-        check( netcode_server_client_connected( server, j ) == 1 );
-    }
-
-    check( server->skillz_matches->num_clients_in_match == num_clients );
-
-    for( int i = 0; i < num_clients; ++i )
-        netcode_server_disconnect_client( server, i );
-
-    for( int i = 0; i < num_clients; ++i )
-        free( clients[i] );
-
-    netcode_server_stop( server );
-    netcode_server_destroy( server );
-
-    netcode_network_simulator_destroy( network_simulator );
-
-    free(clients);
-}
-
-void test_skillz_only_two_clients_per_match_with_three_attempting()
-{
-}
-
-void test_skillz_disconnect_frees_match()
-{
-}
-
-void test_skillz_disconnect_frees_one_match_then_the_other_with_four_clients()
-{
-}
-
-
 void test_client_server_keep_alive()
 {
     struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
@@ -8030,6 +7909,137 @@ void test_loopback()
     netcode_network_simulator_destroy( network_simulator );
 }
 
+void test_skillz_add_two_clients_to_match()
+{
+    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
+
+    network_simulator->latency_milliseconds = 250;
+    network_simulator->jitter_milliseconds = 250;
+    network_simulator->packet_loss_percent = 5;
+    network_simulator->duplicate_packet_percent = 10;
+
+    double time = 0.0;
+    double delta_time = 1.0 / 10.0;
+
+    int num_clients = 2;
+
+    struct netcode_server_t * server = netcode_server_create_internal("[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
+    check( server );
+    netcode_server_start( server, num_clients );
+
+    struct netcode_client_t ** clients = (struct netcode_client_t **) malloc( sizeof( struct netcode_client_t* ) * num_clients );
+    check(clients);
+
+    uint64_t token_sequence = 0;
+
+    // Client things.
+    for( int i = 0; i < num_clients; ++i )
+    {
+        char client_address[NETCODE_MAX_ADDRESS_STRING_LENGTH];
+        sprintf( client_address, "[::]:%d", 50000 + i );
+
+        *(clients + i) = netcode_client_create_internal( client_address, time, network_simulator, NULL, NULL, NULL );
+
+
+        check( clients[i] );
+
+        uint64_t client_id = i;
+        netcode_random_bytes( (uint8_t*) &client_id, 8 );
+
+        NETCODE_CONST char * server_address = "[::1]:40000";
+
+        uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+
+        check( netcode_generate_connect_token( 1,
+                                               &server_address,
+                                               TEST_CONNECT_TOKEN_EXPIRY,
+                                               TEST_TIMEOUT_SECONDS,
+                                               client_id,
+                                               TEST_PROTOCOL_ID,
+                                               token_sequence++,
+                                               private_key,
+                                               connect_token) );
+
+        netcode_client_connect( clients[i], connect_token );
+    }
+
+    // Connect the two clients.
+
+    while( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        for ( int j = 0; j < num_clients; ++j)
+        {
+            netcode_client_update( clients[j], time );
+        }
+
+        netcode_server_update( server, time );
+
+        int num_connected_clients = 0;
+
+        for( int j = 0; j < num_clients; ++j )
+        {
+            if( netcode_client_state( clients[j] ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+                break;
+
+            if( netcode_client_state( clients[j] ) == NETCODE_CLIENT_STATE_CONNECTED )
+                num_connected_clients++;
+        }
+
+        if ( num_connected_clients == num_clients )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_server_num_connected_clients( server ) == num_clients );
+
+    for( int j = 0; j < num_clients; ++j)
+    {
+        check( netcode_client_state( clients[j] ) == NETCODE_CLIENT_STATE_CONNECTED );
+        check( netcode_server_client_connected( server, j ) == 1 );
+    }
+
+    // Check if match was created with 2 clients.
+
+    int match_id = 111;
+    skillz_match_t * match = NULL;
+
+    HASH_FIND_INT( server->skillz_matches, &match_id, match );
+    check( match->num_clients_in_match == num_clients );
+
+    for( int i = 0; i < num_clients; ++i )
+        netcode_server_disconnect_client( server, i );
+
+    for( int i = 0; i < num_clients; ++i )
+        netcode_client_destroy( clients[i] );
+
+    // Check if match was destroyed after disconnection.
+    HASH_FIND_INT( server->skillz_matches, &match_id, match );
+    check( match == NULL );
+
+    netcode_server_stop( server );
+    netcode_server_destroy( server );
+
+    netcode_network_simulator_destroy( network_simulator );
+
+    free(clients);
+}
+
+void test_skillz_only_two_clients_per_match_with_three_attempting()
+{
+}
+
+void test_skillz_disconnect_frees_match()
+{
+}
+
+void test_skillz_disconnect_frees_one_match_then_the_other_with_four_clients()
+{
+}
+
+
 #define RUN_TEST( test_function )                                           \
     do                                                                      \
     {                                                                       \
@@ -8058,7 +8068,6 @@ void netcode_test()
         RUN_TEST( test_encryption_manager );
         RUN_TEST( test_replay_protection );
         RUN_TEST( test_client_server_connect );
-        RUN_TEST( test_skillz_add_two_clients_to_match );
         RUN_TEST( test_client_server_keep_alive );
         RUN_TEST( test_client_server_multiple_clients );
         RUN_TEST( test_client_server_multiple_servers );
@@ -8073,6 +8082,7 @@ void netcode_test()
         RUN_TEST( test_client_reconnect );
         RUN_TEST( test_disable_timeout );
         RUN_TEST( test_loopback );
+        RUN_TEST( test_skillz_add_two_clients_to_match );
     }
 }
 

--- a/netcode.c
+++ b/netcode.c
@@ -4712,7 +4712,8 @@ void netcode_server_connect_disconnect_callback( struct netcode_server_t * serve
     server->connect_disconnect_callback_function = callback_function;
 }
 
-void netcode_server_connect_loopback_client( struct netcode_server_t * server, int client_index, uint64_t client_id, NETCODE_CONST uint8_t * user_data )
+void netcode_server_connect_loopback_client( struct netcode_server_t * server, int client_index, uint64_t client_id,
+                                             uint64_t skillz_match_id, NETCODE_CONST uint8_t * user_data )
 {
     netcode_assert( server );
     netcode_assert( client_index >= 0 );
@@ -4729,6 +4730,7 @@ void netcode_server_connect_loopback_client( struct netcode_server_t * server, i
     server->client_confirmed[client_index] = 1;
     server->client_encryption_index[client_index] = -1;
     server->client_id[client_index] = client_id;
+    server->skillz_match_id[client_index] = skillz_match_id;
     server->client_sequence[client_index] = 0;
     memset( &server->client_address[client_index], 0, sizeof( struct netcode_address_t ) );
     server->client_last_packet_send_time[client_index] = server->time;
@@ -6776,1177 +6778,1226 @@ void test_client_server_multiple_servers()
     netcode_network_simulator_destroy( network_simulator );
 }
 
-//void test_client_error_connect_token_expired()
-//{
-//    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
-//
-//    network_simulator->latency_milliseconds = 250;
-//    network_simulator->jitter_milliseconds = 250;
-//    network_simulator->packet_loss_percent = 5;
-//    network_simulator->duplicate_packet_percent = 10;
-//
-//    double time = 0.0;
-//
-//    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
-//
-//    check( client );
-//
-//    NETCODE_CONST char * server_address = "[::1]:40000";
-//
-//    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
-//
-//    uint64_t client_id = 0;
-//    netcode_random_bytes( (uint8_t*) &client_id, 8 );
-//
-//    check( netcode_generate_connect_token( 1, &server_address, 0, TEST_TIMEOUT_SECONDS, client_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
-//
-//    netcode_client_connect( client, connect_token );
-//
-//    netcode_client_update( client, time );
-//
-//    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECT_TOKEN_EXPIRED );
-//
-//    netcode_client_destroy( client );
-//
-//    netcode_network_simulator_destroy( network_simulator );
-//}
-//
-//void test_client_error_invalid_connect_token()
-//{
-//    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
-//
-//    network_simulator->latency_milliseconds = 250;
-//    network_simulator->jitter_milliseconds = 250;
-//    network_simulator->packet_loss_percent = 5;
-//    network_simulator->duplicate_packet_percent = 10;
-//
-//    double time = 0.0;
-//
-//    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
-//
-//    check( client );
-//
-//    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
-//    netcode_random_bytes( connect_token, NETCODE_CONNECT_TOKEN_BYTES );
-//
-//    uint64_t client_id = 0;
-//    netcode_random_bytes( (uint8_t*) &client_id, 8 );
-//
-//    netcode_client_connect( client, connect_token );
-//
-//    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_INVALID_CONNECT_TOKEN );
-//
-//    netcode_client_destroy( client );
-//
-//    netcode_network_simulator_destroy( network_simulator );
-//}
-//
-//void test_client_error_connection_timed_out()
-//{
-//    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
-//
-//    network_simulator->latency_milliseconds = 250;
-//    network_simulator->jitter_milliseconds = 250;
-//    network_simulator->packet_loss_percent = 5;
-//    network_simulator->duplicate_packet_percent = 10;
-//
-//    double time = 0.0;
-//    double delta_time = 1.0 / 10.0;
-//
-//    // connect a client to the server
-//
-//    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
-//
-//    check( client );
-//
-//    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
-//
-//    check( server );
-//
-//    netcode_server_start( server, 1 );
-//
-//    NETCODE_CONST char * server_address = "[::1]:40000";
-//
-//    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
-//
-//    uint64_t client_id = 0;
-//    netcode_random_bytes( (uint8_t*) &client_id, 8 );
-//
-//    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
-//
-//    netcode_client_connect( client, connect_token );
-//
-//    while ( 1 )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        netcode_client_update( client, time );
-//
-//        netcode_server_update( server, time );
-//
-//        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-//            break;
-//
-//        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED )
-//            break;
-//
-//        time += delta_time;
-//    }
-//
-//    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED );
-//    check( netcode_client_index( client ) == 0 );
-//    check( netcode_server_client_connected( server, 0 ) == 1 );
-//    check( netcode_server_num_connected_clients( server ) == 1 );
-//
-//    // now disable updating the server and verify that the client times out
-//
-//    while ( 1 )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        netcode_client_update( client, time );
-//
-//        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-//            break;
-//
-//        time += delta_time;
-//    }
-//
-//    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTION_TIMED_OUT );
-//
-//    netcode_server_destroy( server );
-//
-//    netcode_client_destroy( client );
-//
-//    netcode_network_simulator_destroy( network_simulator );
-//}
-//
-//void test_client_error_connection_response_timeout()
-//{
-//    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
-//
-//    network_simulator->latency_milliseconds = 250;
-//    network_simulator->jitter_milliseconds = 250;
-//    network_simulator->packet_loss_percent = 5;
-//    network_simulator->duplicate_packet_percent = 10;
-//
-//    double time = 0.0;
-//    double delta_time = 1.0 / 10.0;
-//
-//    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
-//
-//    check( client );
-//
-//    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
-//
-//    check( server );
-//
-//    server->flags = NETCODE_SERVER_FLAG_IGNORE_CONNECTION_RESPONSE_PACKETS;
-//
-//    netcode_server_start( server, 1 );
-//
-//    NETCODE_CONST char * server_address = "[::1]:40000";
-//
-//    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
-//
-//    uint64_t client_id = 0;
-//    netcode_random_bytes( (uint8_t*) &client_id, 8 );
-//
-//    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
-//
-//    netcode_client_connect( client, connect_token );
-//
-//    while ( 1 )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        netcode_client_update( client, time );
-//
-//        netcode_server_update( server, time );
-//
-//        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-//            break;
-//
-//        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED  )
-//            break;
-//
-//        time += delta_time;
-//    }
-//
-//    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTION_RESPONSE_TIMED_OUT );
-//
-//    netcode_server_destroy( server );
-//
-//    netcode_client_destroy( client );
-//
-//    netcode_network_simulator_destroy( network_simulator );
-//}
-//
-//void test_client_error_connection_request_timeout()
-//{
-//    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
-//
-//    network_simulator->latency_milliseconds = 250;
-//    network_simulator->jitter_milliseconds = 250;
-//    network_simulator->packet_loss_percent = 5;
-//    network_simulator->duplicate_packet_percent = 10;
-//
-//    double time = 0.0;
-//    double delta_time = 1.0 / 60.0;
-//
-//    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
-//
-//    check( client );
-//
-//    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
-//
-//    check( server );
-//
-//    server->flags = NETCODE_SERVER_FLAG_IGNORE_CONNECTION_REQUEST_PACKETS;
-//
-//    netcode_server_start( server, 1 );
-//
-//    NETCODE_CONST char * server_address = "[::1]:40000";
-//
-//    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
-//
-//    uint64_t client_id = 0;
-//    netcode_random_bytes( (uint8_t*) &client_id, 8 );
-//
-//    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
-//
-//    netcode_client_connect( client, connect_token );
-//
-//    while ( 1 )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        netcode_client_update( client, time );
-//
-//        netcode_server_update( server, time );
-//
-//        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-//            break;
-//
-//        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED  )
-//            break;
-//
-//        time += delta_time;
-//    }
-//
-//    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTION_REQUEST_TIMED_OUT );
-//
-//    netcode_server_destroy( server );
-//
-//    netcode_client_destroy( client );
-//
-//    netcode_network_simulator_destroy( network_simulator );
-//}
-//
-//void test_client_error_connection_denied()
-//{
-//    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
-//
-//    network_simulator->latency_milliseconds = 250;
-//    network_simulator->jitter_milliseconds = 250;
-//    network_simulator->packet_loss_percent = 5;
-//    network_simulator->duplicate_packet_percent = 10;
-//
-//    // start a server and connect one client
-//
-//    double time = 0.0;
-//    double delta_time = 1.0 / 10.0;
-//
-//    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
-//
-//    check( client );
-//
-//    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
-//
-//    check( server );
-//
-//    netcode_server_start( server, 1 );
-//
-//    NETCODE_CONST char * server_address = "[::1]:40000";
-//
-//    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
-//
-//    uint64_t client_id = 0;
-//    netcode_random_bytes( (uint8_t*) &client_id, 8 );
-//
-//    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
-//
-//    netcode_client_connect( client, connect_token );
-//
-//    while ( 1 )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        netcode_client_update( client, time );
-//
-//        netcode_server_update( server, time );
-//
-//        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-//            break;
-//
-//        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED )
-//            break;
-//
-//        time += delta_time;
-//    }
-//
-//    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED );
-//    check( netcode_client_index( client ) == 0 );
-//    check( netcode_server_client_connected( server, 0 ) == 1 );
-//    check( netcode_server_num_connected_clients( server ) == 1 );
-//
-//    // now attempt to connect a second client. the connection should be denied.
-//
-//    struct netcode_client_t * client2 = netcode_client_create_internal( "[::]:50001", time, network_simulator, NULL, NULL, NULL );
-//
-//    check( client2 );
-//
-//    uint8_t connect_token2[NETCODE_CONNECT_TOKEN_BYTES];
-//
-//    uint64_t client_id2 = 0;
-//    netcode_random_bytes( (uint8_t*) &client_id2, 8 );
-//
-//    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id2, TEST_PROTOCOL_ID, 0, private_key, connect_token2 ) );
-//
-//    netcode_client_connect( client2, connect_token2 );
-//
-//    while ( 1 )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        netcode_client_update( client, time );
-//
-//        netcode_client_update( client2, time );
-//
-//        netcode_server_update( server, time );
-//
-//        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-//            break;
-//
-//        if ( netcode_client_state( client2 ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-//            break;
-//
-//        time += delta_time;
-//    }
-//
-//    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED );
-//    check( netcode_client_state( client2 ) == NETCODE_CLIENT_STATE_CONNECTION_DENIED );
-//    check( netcode_server_client_connected( server, 0 ) == 1 );
-//    check( netcode_server_num_connected_clients( server ) == 1 );
-//
-//    netcode_server_destroy( server );
-//
-//    netcode_client_destroy( client );
-//
-//    netcode_client_destroy( client2 );
-//
-//    netcode_network_simulator_destroy( network_simulator );
-//}
-//
-//void test_client_side_disconnect()
-//{
-//    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
-//
-//    // start a server and connect one client
-//
-//    double time = 0.0;
-//    double delta_time = 1.0 / 10.0;
-//
-//    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
-//
-//    check( client );
-//
-//    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
-//
-//    check( server );
-//
-//    netcode_server_start( server, 1 );
-//
-//    NETCODE_CONST char * server_address = "[::1]:40000";
-//
-//    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
-//
-//    uint64_t client_id = 0;
-//    netcode_random_bytes( (uint8_t*) &client_id, 8 );
-//
-//    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
-//
-//    netcode_client_connect( client, connect_token );
-//
-//    while ( 1 )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        netcode_client_update( client, time );
-//
-//        netcode_server_update( server, time );
-//
-//        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-//            break;
-//
-//        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED )
-//            break;
-//
-//        time += delta_time;
-//    }
-//
-//    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED );
-//    check( netcode_client_index( client ) == 0 );
-//    check( netcode_server_client_connected( server, 0 ) == 1 );
-//    check( netcode_server_num_connected_clients( server ) == 1 );
-//
-//    // disconnect client side and verify that the server sees that client disconnect cleanly, rather than timing out.
-//
-//    netcode_client_disconnect( client );
-//
-//    int i;
-//    for ( i = 0; i < 10; ++i )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        netcode_client_update( client, time );
-//
-//        netcode_server_update( server, time );
-//
-//        if ( netcode_server_client_connected( server, 0 ) == 0 )
-//            break;
-//
-//        time += delta_time;
-//    }
-//
-//    check( netcode_server_client_connected( server, 0 ) == 0 );
-//    check( netcode_server_num_connected_clients( server ) == 0 );
-//
-//    netcode_server_destroy( server );
-//
-//    netcode_client_destroy( client );
-//
-//    netcode_network_simulator_destroy( network_simulator );
-//}
-//
-//void test_server_side_disconnect()
-//{
-//    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
-//
-//    // start a server and connect one client
-//
-//    double time = 0.0;
-//    double delta_time = 1.0 / 10.0;
-//
-//    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
-//
-//    check( client );
-//
-//    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
-//
-//    check( server );
-//
-//    netcode_server_start( server, 1 );
-//
-//    NETCODE_CONST char * server_address = "[::1]:40000";
-//
-//    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
-//
-//    uint64_t client_id = 0;
-//    netcode_random_bytes( (uint8_t*) &client_id, 8 );
-//
-//    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
-//
-//    netcode_client_connect( client, connect_token );
-//
-//    while ( 1 )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        netcode_client_update( client, time );
-//
-//        netcode_server_update( server, time );
-//
-//        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-//            break;
-//
-//        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED )
-//            break;
-//
-//        time += delta_time;
-//    }
-//
-//    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED );
-//    check( netcode_client_index( client ) == 0 );
-//    check( netcode_server_client_connected( server, 0 ) == 1 );
-//    check( netcode_server_num_connected_clients( server ) == 1 );
-//
-//    // disconnect server side and verify that the client disconnects cleanly, rather than timing out.
-//
-//    netcode_server_disconnect_client( server, 0 );
-//
-//    int i;
-//    for ( i = 0; i < 10; ++i )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        netcode_client_update( client, time );
-//
-//        netcode_server_update( server, time );
-//
-//        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_DISCONNECTED )
-//            break;
-//
-//        time += delta_time;
-//    }
-//
-//    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_DISCONNECTED );
-//    check( netcode_server_client_connected( server, 0 ) == 0 );
-//    check( netcode_server_num_connected_clients( server ) == 0 );
-//
-//    netcode_server_destroy( server );
-//
-//    netcode_client_destroy( client );
-//
-//    netcode_network_simulator_destroy( network_simulator );
-//}
-//
-//void test_client_reconnect()
-//{
-//    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
-//
-//    network_simulator->latency_milliseconds = 250;
-//    network_simulator->jitter_milliseconds = 250;
-//    network_simulator->packet_loss_percent = 5;
-//    network_simulator->duplicate_packet_percent = 10;
-//
-//    // start a server and connect one client
-//
-//    double time = 0.0;
-//    double delta_time = 1.0 / 10.0;
-//
-//    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
-//
-//    check( client );
-//
-//    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
-//
-//    check( server );
-//
-//    netcode_server_start( server, 1 );
-//
-//    NETCODE_CONST char * server_address = "[::1]:40000";
-//
-//    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
-//
-//    uint64_t client_id = 0;
-//    netcode_random_bytes( (uint8_t*) &client_id, 8 );
-//
-//    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
-//
-//    netcode_client_connect( client, connect_token );
-//
-//    while ( 1 )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        netcode_client_update( client, time );
-//
-//        netcode_server_update( server, time );
-//
-//        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-//            break;
-//
-//        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED )
-//            break;
-//
-//        time += delta_time;
-//    }
-//
-//    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED );
-//    check( netcode_client_index( client ) == 0 );
-//    check( netcode_server_client_connected( server, 0 ) == 1 );
-//    check( netcode_server_num_connected_clients( server ) == 1 );
-//
-//    // disconnect client on the server-side and wait until client sees the disconnect
-//
-//    netcode_network_simulator_reset( network_simulator );
-//
-//    netcode_server_disconnect_client( server, 0 );
-//
-//    while ( 1 )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        netcode_client_update( client, time );
-//
-//        netcode_server_update( server, time );
-//
-//        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-//            break;
-//
-//        time += delta_time;
-//    }
-//
-//    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_DISCONNECTED );
-//    check( netcode_server_client_connected( server, 0 ) == 0 );
-//    check( netcode_server_num_connected_clients( server ) == 0 );
-//
-//    // now reconnect the client and verify they connect
-//
-//    netcode_network_simulator_reset( network_simulator );
-//
-//    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
-//
-//    netcode_client_connect( client, connect_token );
-//
-//    while ( 1 )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        netcode_client_update( client, time );
-//
-//        netcode_server_update( server, time );
-//
-//        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-//            break;
-//
-//        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED )
-//            break;
-//
-//        time += delta_time;
-//    }
-//
-//    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED );
-//    check( netcode_client_index( client ) == 0 );
-//    check( netcode_server_client_connected( server, 0 ) == 1 );
-//    check( netcode_server_num_connected_clients( server ) == 1 );
-//
-//    netcode_server_destroy( server );
-//
-//    netcode_client_destroy( client );
-//
-//    netcode_network_simulator_destroy( network_simulator );
-//}
-//
-//struct test_loopback_context_t
-//{
-//    struct netcode_client_t * client;
-//    struct netcode_server_t * server;
-//    int num_loopback_packets_sent_to_client;
-//    int num_loopback_packets_sent_to_server;
-//};
-//
-//void client_send_loopback_packet_callback( void * _context, int client_index, NETCODE_CONST uint8_t * packet_data, int packet_bytes, uint64_t packet_sequence )
-//{
-//    (void) packet_sequence;
-//    check( _context );
-//    check( client_index == 0 );
-//    check( packet_data );
-//    check( packet_bytes == NETCODE_MAX_PACKET_SIZE );
-//    int i;
-//    for ( i = 0; i < packet_bytes; ++i )
-//    {
-//        check( packet_data[i] == (uint8_t) i );
-//    }
-//    struct test_loopback_context_t * context = (struct test_loopback_context_t*) _context;
-//    context->num_loopback_packets_sent_to_server++;
-//    netcode_server_process_loopback_packet( context->server, client_index, packet_data, packet_bytes, packet_sequence );
-//}
-//
-//void server_send_loopback_packet_callback( void * _context, int client_index, NETCODE_CONST uint8_t * packet_data, int packet_bytes, uint64_t packet_sequence )
-//{
-//    (void) packet_sequence;
-//    check( _context );
-//    check( client_index == 0 );
-//    check( packet_data );
-//    check( packet_bytes == NETCODE_MAX_PACKET_SIZE );
-//    int i;
-//    for ( i = 0; i < packet_bytes; ++i )
-//    {
-//        check( packet_data[i] == (uint8_t) i );
-//    }
-//    struct test_loopback_context_t * context = (struct test_loopback_context_t*) _context;
-//    context->num_loopback_packets_sent_to_client++;
-//    netcode_client_process_loopback_packet( context->client, packet_data, packet_bytes, packet_sequence );
-//}
-//
-//void test_disable_timeout()
-//{
-//    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
-//
-//    network_simulator->latency_milliseconds = 250;
-//    network_simulator->jitter_milliseconds = 250;
-//    network_simulator->packet_loss_percent = 5;
-//    network_simulator->duplicate_packet_percent = 10;
-//
-//    double time = 0.0;
-//    double delta_time = 1.0 / 10.0;
-//
-//    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
-//
-//    check( client );
-//
-//    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
-//
-//    check( server );
-//
-//    netcode_server_start( server, 1 );
-//
-//    NETCODE_CONST char * server_address = "[::1]:40000";
-//
-//    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
-//
-//    uint64_t client_id = 0;
-//    netcode_random_bytes( (uint8_t*) &client_id, 8 );
-//
-//    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, -1, client_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
-//
-//    netcode_client_connect( client, connect_token );
-//
-//    while ( 1 )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        netcode_client_update( client, time );
-//
-//        netcode_server_update( server, time );
-//
-//        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-//            break;
-//
-//        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED )
-//            break;
-//
-//        time += delta_time;
-//    }
-//
-//    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED );
-//    check( netcode_client_index( client ) == 0 );
-//    check( netcode_server_client_connected( server, 0 ) == 1 );
-//    check( netcode_server_num_connected_clients( server ) == 1 );
-//
-//    int server_num_packets_received = 0;
-//    int client_num_packets_received = 0;
-//
-//    uint8_t packet_data[NETCODE_MAX_PACKET_SIZE];
-//    int i;
-//    for ( i = 0; i < NETCODE_MAX_PACKET_SIZE; ++i )
-//        packet_data[i] = (uint8_t) i;
-//
-//    while ( 1 )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        netcode_client_update( client, time );
-//
-//        netcode_server_update( server, time );
-//
-//        netcode_client_send_packet( client, packet_data, NETCODE_MAX_PACKET_SIZE );
-//
-//        netcode_server_send_packet( server, 0, packet_data, NETCODE_MAX_PACKET_SIZE );
-//
-//        while ( 1 )
-//        {
-//            int packet_bytes;
-//            uint64_t packet_sequence;
-//            uint8_t * packet = netcode_client_receive_packet( client, &packet_bytes, &packet_sequence );
-//            if ( !packet )
-//                break;
-//            (void) packet_sequence;
-//            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
-//            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
-//            client_num_packets_received++;
-//            netcode_client_free_packet( client, packet );
-//        }
-//
-//        while ( 1 )
-//        {
-//            int packet_bytes;
-//            uint64_t packet_sequence;
-//            void * packet = netcode_server_receive_packet( server, 0, &packet_bytes, &packet_sequence );
-//            if ( !packet )
-//                break;
-//            (void) packet_sequence;
-//            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
-//            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
-//            server_num_packets_received++;
-//            netcode_server_free_packet( server, packet );
-//        }
-//
-//        if ( client_num_packets_received >= 10 && server_num_packets_received >= 10 )
-//        {
-//            if ( netcode_server_client_connected( server, 0 ) )
-//            {
-//                netcode_server_disconnect_client( server, 0 );
-//            }
-//        }
-//
-//        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-//            break;
-//
-//        time += 1000.0f;        // normally this would timeout the client
-//    }
-//
-//    check( client_num_packets_received >= 10 && server_num_packets_received >= 10 );
-//
-//    netcode_server_destroy( server );
-//
-//    netcode_client_destroy( client );
-//
-//    netcode_network_simulator_destroy( network_simulator );
-//}
-//
-//void test_loopback()
-//{
-//    struct test_loopback_context_t context;
-//    memset( &context, 0, sizeof( context ) );
-//
-//    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
-//
-//    network_simulator->latency_milliseconds = 250;
-//    network_simulator->jitter_milliseconds = 250;
-//    network_simulator->packet_loss_percent = 5;
-//    network_simulator->duplicate_packet_percent = 10;
-//
-//    double time = 0.0;
-//    double delta_time = 1.0 / 10.0;
-//
-//    // start the server
-//
-//    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
-//    check( server );
-//    int max_clients = 2;
-//    netcode_server_start( server, max_clients );
-//    context.server = server;
-//
-//    // connect a loopback client in slot 0
-//
-//    struct netcode_client_t * loopback_client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
-//    check( loopback_client );
-//    netcode_client_connect_loopback( loopback_client, 0, max_clients );
-//    netcode_client_send_loopback_packet_callback( loopback_client, &context, client_send_loopback_packet_callback );
-//    context.client = loopback_client;
-//
-//    check( netcode_client_index( loopback_client ) == 0 );
-//    check( netcode_client_loopback( loopback_client ) == 1 );
-//    check( netcode_client_max_clients( loopback_client ) == max_clients );
-//    check( netcode_client_state( loopback_client ) == NETCODE_CLIENT_STATE_CONNECTED );
-//
-//    uint64_t client_id = 0;
-//    netcode_random_bytes( (uint8_t*) &client_id, 8 );
-//    netcode_server_connect_loopback_client( server, 0, client_id, NULL );
-//
-//    check( netcode_server_client_loopback( server, 0 ) == 1 );
-//    check( netcode_server_client_connected( server, 0 ) == 1 );
-//    check( netcode_server_num_connected_clients( server ) == 1 );
-//
-//    netcode_server_send_loopback_packet_callback( server, &context, server_send_loopback_packet_callback );
-//
-//    // connect a regular client in the other slot
-//
-//    struct netcode_client_t * regular_client = netcode_client_create_internal( "[::]:50001", time, network_simulator, NULL, NULL, NULL );
-//
-//    check( regular_client );
-//
-//    NETCODE_CONST char * server_address = "[::1]:40000";
-//
-//    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
-//    netcode_random_bytes( (uint8_t*) &client_id, 8 );
-//    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
-//
-//    netcode_client_connect( regular_client, connect_token );
-//
-//    while ( 1 )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        netcode_client_update( regular_client, time );
-//
-//        netcode_server_update( server, time );
-//
-//        if ( netcode_client_state( regular_client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-//            break;
-//
-//        if ( netcode_client_state( regular_client ) == NETCODE_CLIENT_STATE_CONNECTED )
-//            break;
-//
-//        time += delta_time;
-//    }
-//
-//    check( netcode_client_state( regular_client ) == NETCODE_CLIENT_STATE_CONNECTED );
-//    check( netcode_client_index( regular_client ) == 1 );
-//    check( netcode_server_client_connected( server, 0 ) == 1 );
-//    check( netcode_server_client_connected( server, 1 ) == 1 );
-//    check( netcode_server_client_loopback( server, 0 ) == 1 );
-//    check( netcode_server_client_loopback( server, 1 ) == 0 );
-//    check( netcode_server_num_connected_clients( server ) == 2 );
-//
-//    // test that we can exchange packets for the regular client and the loopback client
-//
-//    int loopback_client_num_packets_received = 0;
-//    int loopback_server_num_packets_received = 0;
-//    int regular_server_num_packets_received = 0;
-//    int regular_client_num_packets_received = 0;
-//
-//    uint8_t packet_data[NETCODE_MAX_PACKET_SIZE];
-//    int i;
-//    for ( i = 0; i < NETCODE_MAX_PACKET_SIZE; ++i )
-//        packet_data[i] = (uint8_t) i;
-//
-//    while ( 1 )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        netcode_client_update( regular_client, time );
-//
-//        netcode_server_update( server, time );
-//
-//        netcode_client_send_packet( loopback_client, packet_data, NETCODE_MAX_PACKET_SIZE );
-//
-//        netcode_client_send_packet( regular_client, packet_data, NETCODE_MAX_PACKET_SIZE );
-//
-//        netcode_server_send_packet( server, 0, packet_data, NETCODE_MAX_PACKET_SIZE );
-//
-//        netcode_server_send_packet( server, 1, packet_data, NETCODE_MAX_PACKET_SIZE );
-//
-//        while ( 1 )
-//        {
-//            int packet_bytes;
-//            uint64_t packet_sequence;
-//            uint8_t * packet = netcode_client_receive_packet( loopback_client, &packet_bytes, &packet_sequence );
-//            if ( !packet )
-//                break;
-//            (void) packet_sequence;
-//            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
-//            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
-//            loopback_client_num_packets_received++;
-//            netcode_client_free_packet( loopback_client, packet );
-//        }
-//
-//        while ( 1 )
-//        {
-//            int packet_bytes;
-//            uint64_t packet_sequence;
-//            uint8_t * packet = netcode_client_receive_packet( regular_client, &packet_bytes, &packet_sequence );
-//            if ( !packet )
-//                break;
-//            (void) packet_sequence;
-//            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
-//            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
-//            regular_client_num_packets_received++;
-//            netcode_client_free_packet( regular_client, packet );
-//        }
-//
-//        while ( 1 )
-//        {
-//            int packet_bytes;
-//            uint64_t packet_sequence;
-//            void * packet = netcode_server_receive_packet( server, 0, &packet_bytes, &packet_sequence );
-//            if ( !packet )
-//                break;
-//            (void) packet_sequence;
-//            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
-//            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
-//            loopback_server_num_packets_received++;
-//            netcode_server_free_packet( server, packet );
-//        }
-//
-//        while ( 1 )
-//        {
-//            int packet_bytes;
-//            uint64_t packet_sequence;
-//            void * packet = netcode_server_receive_packet( server, 1, &packet_bytes, &packet_sequence );
-//            if ( !packet )
-//                break;
-//            (void) packet_sequence;
-//            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
-//            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
-//            regular_server_num_packets_received++;
-//            netcode_server_free_packet( server, packet );
-//        }
-//
-//        if ( loopback_client_num_packets_received >= 10 && loopback_server_num_packets_received >= 10 &&
-//             regular_client_num_packets_received >= 10 && regular_server_num_packets_received >= 10 )
-//            break;
-//
-//        if ( netcode_client_state( regular_client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-//            break;
-//
-//        time += delta_time;
-//    }
-//
-//    check( loopback_client_num_packets_received >= 10 );
-//    check( loopback_server_num_packets_received >= 10 );
-//    check( regular_client_num_packets_received >= 10 );
-//    check( regular_server_num_packets_received >= 10 );
-//    check( context.num_loopback_packets_sent_to_client >= 10 );
-//    check( context.num_loopback_packets_sent_to_server >= 10 );
-//
-//    // verify that we can disconnect the loopback client
-//
-//    check( netcode_server_client_loopback( server, 0 ) == 1 );
-//    check( netcode_server_client_connected( server, 0 ) == 1 );
-//    check( netcode_server_num_connected_clients( server ) == 2 );
-//
-//    netcode_server_disconnect_loopback_client( server, 0 );
-//
-//    check( netcode_server_client_loopback( server, 0 ) == 0 );
-//    check( netcode_server_client_connected( server, 0 ) == 0 );
-//    check( netcode_server_num_connected_clients( server ) == 1 );
-//
-//    netcode_client_disconnect_loopback( loopback_client );
-//
-//    check( netcode_client_state( loopback_client ) == NETCODE_CLIENT_STATE_DISCONNECTED );
-//
-//    // verify that we can reconnect the loopback client
-//
-//    netcode_random_bytes( (uint8_t*) &client_id, 8 );
-//    netcode_server_connect_loopback_client( server, 0, client_id, NULL );
-//
-//    check( netcode_server_client_loopback( server, 0 ) == 1 );
-//    check( netcode_server_client_loopback( server, 1 ) == 0 );
-//    check( netcode_server_client_connected( server, 0 ) == 1 );
-//    check( netcode_server_client_connected( server, 1 ) == 1 );
-//    check( netcode_server_num_connected_clients( server ) == 2 );
-//
-//    netcode_client_connect_loopback( loopback_client, 0, max_clients );
-//
-//    check( netcode_client_index( loopback_client ) == 0 );
-//    check( netcode_client_loopback( loopback_client ) == 1 );
-//    check( netcode_client_max_clients( loopback_client ) == max_clients );
-//    check( netcode_client_state( loopback_client ) == NETCODE_CLIENT_STATE_CONNECTED );
-//
-//    // verify that we can exchange packets for both regular and loopback client post reconnect
-//
-//    loopback_server_num_packets_received = 0;
-//    loopback_server_num_packets_received = 0;
-//    regular_server_num_packets_received = 0;
-//    regular_client_num_packets_received = 0;
-//    context.num_loopback_packets_sent_to_client = 0;
-//    context.num_loopback_packets_sent_to_server = 0;
-//
-//    while ( 1 )
-//    {
-//        netcode_network_simulator_update( network_simulator, time );
-//
-//        netcode_client_update( regular_client, time );
-//
-//        netcode_server_update( server, time );
-//
-//        netcode_client_send_packet( loopback_client, packet_data, NETCODE_MAX_PACKET_SIZE );
-//
-//        netcode_client_send_packet( regular_client, packet_data, NETCODE_MAX_PACKET_SIZE );
-//
-//        netcode_server_send_packet( server, 0, packet_data, NETCODE_MAX_PACKET_SIZE );
-//
-//        netcode_server_send_packet( server, 1, packet_data, NETCODE_MAX_PACKET_SIZE );
-//
-//        while ( 1 )
-//        {
-//            int packet_bytes;
-//            uint64_t packet_sequence;
-//            uint8_t * packet = netcode_client_receive_packet( loopback_client, &packet_bytes, &packet_sequence );
-//            if ( !packet )
-//                break;
-//            (void) packet_sequence;
-//            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
-//            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
-//            loopback_client_num_packets_received++;
-//            netcode_client_free_packet( loopback_client, packet );
-//        }
-//
-//        while ( 1 )
-//        {
-//            int packet_bytes;
-//            uint64_t packet_sequence;
-//            uint8_t * packet = netcode_client_receive_packet( regular_client, &packet_bytes, &packet_sequence );
-//            if ( !packet )
-//                break;
-//            (void) packet_sequence;
-//            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
-//            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
-//            regular_client_num_packets_received++;
-//            netcode_client_free_packet( regular_client, packet );
-//        }
-//
-//        while ( 1 )
-//        {
-//            int packet_bytes;
-//            uint64_t packet_sequence;
-//            void * packet = netcode_server_receive_packet( server, 0, &packet_bytes, &packet_sequence );
-//            if ( !packet )
-//                break;
-//            (void) packet_sequence;
-//            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
-//            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
-//            loopback_server_num_packets_received++;
-//            netcode_server_free_packet( server, packet );
-//        }
-//
-//        while ( 1 )
-//        {
-//            int packet_bytes;
-//            uint64_t packet_sequence;
-//            void * packet = netcode_server_receive_packet( server, 1, &packet_bytes, &packet_sequence );
-//            if ( !packet )
-//                break;
-//            (void) packet_sequence;
-//            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
-//            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
-//            regular_server_num_packets_received++;
-//            netcode_server_free_packet( server, packet );
-//        }
-//
-//        if ( loopback_client_num_packets_received >= 10 && loopback_server_num_packets_received >= 10 &&
-//             regular_client_num_packets_received >= 10 && regular_server_num_packets_received >= 10 )
-//            break;
-//
-//        if ( netcode_client_state( regular_client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
-//            break;
-//
-//        time += delta_time;
-//    }
-//
-//    check( loopback_client_num_packets_received >= 10 );
-//    check( loopback_server_num_packets_received >= 10 );
-//    check( regular_client_num_packets_received >= 10 );
-//    check( regular_server_num_packets_received >= 10 );
-//    check( context.num_loopback_packets_sent_to_client >= 10 );
-//    check( context.num_loopback_packets_sent_to_server >= 10 );
-//
-//    // verify the regular client times out but loopback client doesn't
-//
-//    time += 100000.0;
-//
-//    netcode_server_update( server, time );
-//
-//    check( netcode_server_client_connected( server, 0 ) == 1 );
-//    check( netcode_server_client_connected( server, 1 ) == 0 );
-//
-//    netcode_client_update( loopback_client, time );
-//
-//    check( netcode_client_state( loopback_client ) == NETCODE_CLIENT_STATE_CONNECTED );
-//
-//    // verify that disconnect all clients leaves loopback clients alone
-//
-//    netcode_server_disconnect_all_clients( server );
-//
-//    check( netcode_server_client_connected( server, 0 ) == 1 );
-//    check( netcode_server_client_connected( server, 1 ) == 0 );
-//    check( netcode_server_client_loopback( server, 0 ) == 1 );
-//
-//    // clean up
-//
-//    netcode_client_destroy( regular_client );
-//
-//    netcode_client_destroy( loopback_client );
-//
-//    netcode_server_destroy( server );
-//
-//    netcode_network_simulator_destroy( network_simulator );
-//}
-//
+void test_client_error_connect_token_expired()
+{
+    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
+
+    network_simulator->latency_milliseconds = 250;
+    network_simulator->jitter_milliseconds = 250;
+    network_simulator->packet_loss_percent = 5;
+    network_simulator->duplicate_packet_percent = 10;
+
+    double time = 0.0;
+
+    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
+
+    check( client );
+
+    NETCODE_CONST char * server_address = "[::1]:40000";
+
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+
+    uint64_t client_id = 0;
+    netcode_random_bytes( (uint8_t*) &client_id, 8 );
+
+    uint64_t skillz_match_id = 0;
+    netcode_random_bytes( (uint8_t*) &skillz_match_id, 8 );
+
+    check( netcode_generate_connect_token( 1, &server_address, 0, TEST_TIMEOUT_SECONDS, client_id,
+                                           skillz_match_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
+
+    netcode_client_connect( client, connect_token );
+
+    netcode_client_update( client, time );
+
+    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECT_TOKEN_EXPIRED );
+
+    netcode_client_destroy( client );
+
+    netcode_network_simulator_destroy( network_simulator );
+}
+
+void test_client_error_invalid_connect_token()
+{
+    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
+
+    network_simulator->latency_milliseconds = 250;
+    network_simulator->jitter_milliseconds = 250;
+    network_simulator->packet_loss_percent = 5;
+    network_simulator->duplicate_packet_percent = 10;
+
+    double time = 0.0;
+
+    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
+
+    check( client );
+
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+    netcode_random_bytes( connect_token, NETCODE_CONNECT_TOKEN_BYTES );
+
+    uint64_t client_id = 0;
+    netcode_random_bytes( (uint8_t*) &client_id, 8 );
+
+    uint64_t skillz_match_id = 0;
+    netcode_random_bytes( (uint8_t*) &skillz_match_id, 8 );
+
+    netcode_client_connect( client, connect_token );
+
+    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_INVALID_CONNECT_TOKEN );
+
+    netcode_client_destroy( client );
+
+    netcode_network_simulator_destroy( network_simulator );
+}
+
+void test_client_error_connection_timed_out()
+{
+    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
+
+    network_simulator->latency_milliseconds = 250;
+    network_simulator->jitter_milliseconds = 250;
+    network_simulator->packet_loss_percent = 5;
+    network_simulator->duplicate_packet_percent = 10;
+
+    double time = 0.0;
+    double delta_time = 1.0 / 10.0;
+
+    // connect a client to the server
+
+    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
+
+    check( client );
+
+    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
+
+    check( server );
+
+    netcode_server_start( server, 1 );
+
+    NETCODE_CONST char * server_address = "[::1]:40000";
+
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+
+    uint64_t client_id = 0;
+    netcode_random_bytes( (uint8_t*) &client_id, 8 );
+
+    uint64_t skillz_match_id = 0;
+    netcode_random_bytes( (uint8_t*) &skillz_match_id, 8 );
+
+    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id,
+                                           skillz_match_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
+
+    netcode_client_connect( client, connect_token );
+
+    while ( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        netcode_client_update( client, time );
+
+        netcode_server_update( server, time );
+
+        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED );
+    check( netcode_client_index( client ) == 0 );
+    check( netcode_server_client_connected( server, 0 ) == 1 );
+    check( netcode_server_num_connected_clients( server ) == 1 );
+
+    // now disable updating the server and verify that the client times out
+
+    while ( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        netcode_client_update( client, time );
+
+        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTION_TIMED_OUT );
+
+    netcode_server_destroy( server );
+
+    netcode_client_destroy( client );
+
+    netcode_network_simulator_destroy( network_simulator );
+}
+
+void test_client_error_connection_response_timeout()
+{
+    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
+
+    network_simulator->latency_milliseconds = 250;
+    network_simulator->jitter_milliseconds = 250;
+    network_simulator->packet_loss_percent = 5;
+    network_simulator->duplicate_packet_percent = 10;
+
+    double time = 0.0;
+    double delta_time = 1.0 / 10.0;
+
+    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
+
+    check( client );
+
+    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
+
+    check( server );
+
+    server->flags = NETCODE_SERVER_FLAG_IGNORE_CONNECTION_RESPONSE_PACKETS;
+
+    netcode_server_start( server, 1 );
+
+    NETCODE_CONST char * server_address = "[::1]:40000";
+
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+
+    uint64_t client_id = 0;
+    netcode_random_bytes( (uint8_t*) &client_id, 8 );
+
+    uint64_t skillz_match_id = 0;
+    netcode_random_bytes( (uint8_t*) &skillz_match_id, 8);
+
+    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id,
+                                           skillz_match_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
+
+    netcode_client_connect( client, connect_token );
+
+    while ( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        netcode_client_update( client, time );
+
+        netcode_server_update( server, time );
+
+        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED  )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTION_RESPONSE_TIMED_OUT );
+
+    netcode_server_destroy( server );
+
+    netcode_client_destroy( client );
+
+    netcode_network_simulator_destroy( network_simulator );
+}
+
+void test_client_error_connection_request_timeout()
+{
+    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
+
+    network_simulator->latency_milliseconds = 250;
+    network_simulator->jitter_milliseconds = 250;
+    network_simulator->packet_loss_percent = 5;
+    network_simulator->duplicate_packet_percent = 10;
+
+    double time = 0.0;
+    double delta_time = 1.0 / 60.0;
+
+    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
+
+    check( client );
+
+    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
+
+    check( server );
+
+    server->flags = NETCODE_SERVER_FLAG_IGNORE_CONNECTION_REQUEST_PACKETS;
+
+    netcode_server_start( server, 1 );
+
+    NETCODE_CONST char * server_address = "[::1]:40000";
+
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+
+    uint64_t client_id = 0;
+    netcode_random_bytes( (uint8_t*) &client_id, 8 );
+
+    uint64_t skillz_match_id = 0;
+    netcode_random_bytes( (uint8_t*) &skillz_match_id, 8 );
+
+    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id,
+                                           skillz_match_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
+
+    netcode_client_connect( client, connect_token );
+
+    while ( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        netcode_client_update( client, time );
+
+        netcode_server_update( server, time );
+
+        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED  )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTION_REQUEST_TIMED_OUT );
+
+    netcode_server_destroy( server );
+
+    netcode_client_destroy( client );
+
+    netcode_network_simulator_destroy( network_simulator );
+}
+
+void test_client_error_connection_denied()
+{
+    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
+
+    network_simulator->latency_milliseconds = 250;
+    network_simulator->jitter_milliseconds = 250;
+    network_simulator->packet_loss_percent = 5;
+    network_simulator->duplicate_packet_percent = 10;
+
+    // start a server and connect one client
+
+    double time = 0.0;
+    double delta_time = 1.0 / 10.0;
+
+    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
+
+    check( client );
+
+    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
+
+    check( server );
+
+    netcode_server_start( server, 1 );
+
+    NETCODE_CONST char * server_address = "[::1]:40000";
+
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+
+    uint64_t client_id = 0;
+    netcode_random_bytes( (uint8_t*) &client_id, 8 );
+
+    uint64_t skillz_match_id = 0;
+    netcode_random_bytes( (uint8_t*) &skillz_match_id, 8 );
+
+    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id,
+                                           skillz_match_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
+
+    netcode_client_connect( client, connect_token );
+
+    while ( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        netcode_client_update( client, time );
+
+        netcode_server_update( server, time );
+
+        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED );
+    check( netcode_client_index( client ) == 0 );
+    check( netcode_server_client_connected( server, 0 ) == 1 );
+    check( netcode_server_num_connected_clients( server ) == 1 );
+
+    // now attempt to connect a second client. the connection should be denied.
+
+    struct netcode_client_t * client2 = netcode_client_create_internal( "[::]:50001", time, network_simulator, NULL, NULL, NULL );
+
+    check( client2 );
+
+    uint8_t connect_token2[NETCODE_CONNECT_TOKEN_BYTES];
+
+    uint64_t client_id2 = 0;
+    netcode_random_bytes( (uint8_t*) &client_id2, 8 );
+
+    uint64_t skillz_match_id2 = 0;
+    netcode_random_bytes( (uint8_t*) &skillz_match_id2, 8 );
+
+    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id2,
+                                           skillz_match_id2, TEST_PROTOCOL_ID, 0, private_key, connect_token2 ) );
+
+    netcode_client_connect( client2, connect_token2 );
+
+    while ( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        netcode_client_update( client, time );
+
+        netcode_client_update( client2, time );
+
+        netcode_server_update( server, time );
+
+        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        if ( netcode_client_state( client2 ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED );
+    check( netcode_client_state( client2 ) == NETCODE_CLIENT_STATE_CONNECTION_DENIED );
+    check( netcode_server_client_connected( server, 0 ) == 1 );
+    check( netcode_server_num_connected_clients( server ) == 1 );
+
+    netcode_server_destroy( server );
+
+    netcode_client_destroy( client );
+
+    netcode_client_destroy( client2 );
+
+    netcode_network_simulator_destroy( network_simulator );
+}
+
+void test_client_side_disconnect()
+{
+    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
+
+    // start a server and connect one client
+
+    double time = 0.0;
+    double delta_time = 1.0 / 10.0;
+
+    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
+
+    check( client );
+
+    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
+
+    check( server );
+
+    netcode_server_start( server, 1 );
+
+    NETCODE_CONST char * server_address = "[::1]:40000";
+
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+
+    uint64_t client_id = 0;
+    netcode_random_bytes( (uint8_t*) &client_id, 8 );
+
+    uint64_t skillz_match_id = 0;
+    netcode_random_bytes( (uint8_t*) &skillz_match_id, 8 );
+
+    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id,
+                                           skillz_match_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
+
+    netcode_client_connect( client, connect_token );
+
+    while ( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        netcode_client_update( client, time );
+
+        netcode_server_update( server, time );
+
+        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED );
+    check( netcode_client_index( client ) == 0 );
+    check( netcode_server_client_connected( server, 0 ) == 1 );
+    check( netcode_server_num_connected_clients( server ) == 1 );
+
+    // disconnect client side and verify that the server sees that client disconnect cleanly, rather than timing out.
+
+    netcode_client_disconnect( client );
+
+    int i;
+    for ( i = 0; i < 10; ++i )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        netcode_client_update( client, time );
+
+        netcode_server_update( server, time );
+
+        if ( netcode_server_client_connected( server, 0 ) == 0 )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_server_client_connected( server, 0 ) == 0 );
+    check( netcode_server_num_connected_clients( server ) == 0 );
+
+    netcode_server_destroy( server );
+
+    netcode_client_destroy( client );
+
+    netcode_network_simulator_destroy( network_simulator );
+}
+
+void test_server_side_disconnect()
+{
+    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
+
+    // start a server and connect one client
+
+    double time = 0.0;
+    double delta_time = 1.0 / 10.0;
+
+    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
+
+    check( client );
+
+    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
+
+    check( server );
+
+    netcode_server_start( server, 1 );
+
+    NETCODE_CONST char * server_address = "[::1]:40000";
+
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+
+    uint64_t client_id = 0;
+    netcode_random_bytes( (uint8_t*) &client_id, 8 );
+
+    uint64_t skillz_match_id = 0;
+    netcode_random_bytes( (uint8_t*) &skillz_match_id, 8 );
+
+    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id,
+                                           skillz_match_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
+
+    netcode_client_connect( client, connect_token );
+
+    while ( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        netcode_client_update( client, time );
+
+        netcode_server_update( server, time );
+
+        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED );
+    check( netcode_client_index( client ) == 0 );
+    check( netcode_server_client_connected( server, 0 ) == 1 );
+    check( netcode_server_num_connected_clients( server ) == 1 );
+
+    // disconnect server side and verify that the client disconnects cleanly, rather than timing out.
+
+    netcode_server_disconnect_client( server, 0 );
+
+    int i;
+    for ( i = 0; i < 10; ++i )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        netcode_client_update( client, time );
+
+        netcode_server_update( server, time );
+
+        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_DISCONNECTED );
+    check( netcode_server_client_connected( server, 0 ) == 0 );
+    check( netcode_server_num_connected_clients( server ) == 0 );
+
+    netcode_server_destroy( server );
+
+    netcode_client_destroy( client );
+
+    netcode_network_simulator_destroy( network_simulator );
+}
+
+void test_client_reconnect()
+{
+    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
+
+    network_simulator->latency_milliseconds = 250;
+    network_simulator->jitter_milliseconds = 250;
+    network_simulator->packet_loss_percent = 5;
+    network_simulator->duplicate_packet_percent = 10;
+
+    // start a server and connect one client
+
+    double time = 0.0;
+    double delta_time = 1.0 / 10.0;
+
+    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
+
+    check( client );
+
+    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
+
+    check( server );
+
+    netcode_server_start( server, 1 );
+
+    NETCODE_CONST char * server_address = "[::1]:40000";
+
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+
+    uint64_t client_id = 0;
+    netcode_random_bytes( (uint8_t*) &client_id, 8 );
+
+    uint64_t skillz_match_id = 0;
+    netcode_random_bytes( (uint8_t*) &skillz_match_id, 8 );
+
+    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id,
+                                           skillz_match_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
+
+    netcode_client_connect( client, connect_token );
+
+    while ( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        netcode_client_update( client, time );
+
+        netcode_server_update( server, time );
+
+        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED );
+    check( netcode_client_index( client ) == 0 );
+    check( netcode_server_client_connected( server, 0 ) == 1 );
+    check( netcode_server_num_connected_clients( server ) == 1 );
+
+    // disconnect client on the server-side and wait until client sees the disconnect
+
+    netcode_network_simulator_reset( network_simulator );
+
+    netcode_server_disconnect_client( server, 0 );
+
+    while ( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        netcode_client_update( client, time );
+
+        netcode_server_update( server, time );
+
+        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_DISCONNECTED );
+    check( netcode_server_client_connected( server, 0 ) == 0 );
+    check( netcode_server_num_connected_clients( server ) == 0 );
+
+    // now reconnect the client and verify they connect
+
+    netcode_network_simulator_reset( network_simulator );
+
+    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id,
+                                           skillz_match_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
+
+    netcode_client_connect( client, connect_token );
+
+    while ( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        netcode_client_update( client, time );
+
+        netcode_server_update( server, time );
+
+        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED );
+    check( netcode_client_index( client ) == 0 );
+    check( netcode_server_client_connected( server, 0 ) == 1 );
+    check( netcode_server_num_connected_clients( server ) == 1 );
+
+    netcode_server_destroy( server );
+
+    netcode_client_destroy( client );
+
+    netcode_network_simulator_destroy( network_simulator );
+}
+
+struct test_loopback_context_t
+{
+    struct netcode_client_t * client;
+    struct netcode_server_t * server;
+    int num_loopback_packets_sent_to_client;
+    int num_loopback_packets_sent_to_server;
+};
+
+void client_send_loopback_packet_callback( void * _context, int client_index, NETCODE_CONST uint8_t * packet_data, int packet_bytes, uint64_t packet_sequence )
+{
+    (void) packet_sequence;
+    check( _context );
+    check( client_index == 0 );
+    check( packet_data );
+    check( packet_bytes == NETCODE_MAX_PACKET_SIZE );
+    int i;
+    for ( i = 0; i < packet_bytes; ++i )
+    {
+        check( packet_data[i] == (uint8_t) i );
+    }
+    struct test_loopback_context_t * context = (struct test_loopback_context_t*) _context;
+    context->num_loopback_packets_sent_to_server++;
+    netcode_server_process_loopback_packet( context->server, client_index, packet_data, packet_bytes, packet_sequence );
+}
+
+void server_send_loopback_packet_callback( void * _context, int client_index, NETCODE_CONST uint8_t * packet_data, int packet_bytes, uint64_t packet_sequence )
+{
+    (void) packet_sequence;
+    check( _context );
+    check( client_index == 0 );
+    check( packet_data );
+    check( packet_bytes == NETCODE_MAX_PACKET_SIZE );
+    int i;
+    for ( i = 0; i < packet_bytes; ++i )
+    {
+        check( packet_data[i] == (uint8_t) i );
+    }
+    struct test_loopback_context_t * context = (struct test_loopback_context_t*) _context;
+    context->num_loopback_packets_sent_to_client++;
+    netcode_client_process_loopback_packet( context->client, packet_data, packet_bytes, packet_sequence );
+}
+
+void test_disable_timeout()
+{
+    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
+
+    network_simulator->latency_milliseconds = 250;
+    network_simulator->jitter_milliseconds = 250;
+    network_simulator->packet_loss_percent = 5;
+    network_simulator->duplicate_packet_percent = 10;
+
+    double time = 0.0;
+    double delta_time = 1.0 / 10.0;
+
+    struct netcode_client_t * client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
+
+    check( client );
+
+    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
+
+    check( server );
+
+    netcode_server_start( server, 1 );
+
+    NETCODE_CONST char * server_address = "[::1]:40000";
+
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+
+    uint64_t client_id = 0;
+    netcode_random_bytes( (uint8_t*) &client_id, 8 );
+
+    uint64_t skillz_match_id = 0;
+    netcode_random_bytes( (uint8_t*) &skillz_match_id, 8 );
+
+    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, -1, client_id,
+                                           skillz_match_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
+
+    netcode_client_connect( client, connect_token );
+
+    while ( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        netcode_client_update( client, time );
+
+        netcode_server_update( server, time );
+
+        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED );
+    check( netcode_client_index( client ) == 0 );
+    check( netcode_server_client_connected( server, 0 ) == 1 );
+    check( netcode_server_num_connected_clients( server ) == 1 );
+
+    int server_num_packets_received = 0;
+    int client_num_packets_received = 0;
+
+    uint8_t packet_data[NETCODE_MAX_PACKET_SIZE];
+    int i;
+    for ( i = 0; i < NETCODE_MAX_PACKET_SIZE; ++i )
+        packet_data[i] = (uint8_t) i;
+
+    while ( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        netcode_client_update( client, time );
+
+        netcode_server_update( server, time );
+
+        netcode_client_send_packet( client, packet_data, NETCODE_MAX_PACKET_SIZE );
+
+        netcode_server_send_packet( server, 0, packet_data, NETCODE_MAX_PACKET_SIZE );
+
+        while ( 1 )
+        {
+            int packet_bytes;
+            uint64_t packet_sequence;
+            uint8_t * packet = netcode_client_receive_packet( client, &packet_bytes, &packet_sequence );
+            if ( !packet )
+                break;
+            (void) packet_sequence;
+            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
+            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
+            client_num_packets_received++;
+            netcode_client_free_packet( client, packet );
+        }
+
+        while ( 1 )
+        {
+            int packet_bytes;
+            uint64_t packet_sequence;
+            void * packet = netcode_server_receive_packet( server, 0, &packet_bytes, &packet_sequence );
+            if ( !packet )
+                break;
+            (void) packet_sequence;
+            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
+            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
+            server_num_packets_received++;
+            netcode_server_free_packet( server, packet );
+        }
+
+        if ( client_num_packets_received >= 10 && server_num_packets_received >= 10 )
+        {
+            if ( netcode_server_client_connected( server, 0 ) )
+            {
+                netcode_server_disconnect_client( server, 0 );
+            }
+        }
+
+        if ( netcode_client_state( client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        time += 1000.0f;        // normally this would timeout the client
+    }
+
+    check( client_num_packets_received >= 10 && server_num_packets_received >= 10 );
+
+    netcode_server_destroy( server );
+
+    netcode_client_destroy( client );
+
+    netcode_network_simulator_destroy( network_simulator );
+}
+
+void test_loopback()
+{
+    struct test_loopback_context_t context;
+    memset( &context, 0, sizeof( context ) );
+
+    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
+
+    network_simulator->latency_milliseconds = 250;
+    network_simulator->jitter_milliseconds = 250;
+    network_simulator->packet_loss_percent = 5;
+    network_simulator->duplicate_packet_percent = 10;
+
+    double time = 0.0;
+    double delta_time = 1.0 / 10.0;
+
+    // start the server
+
+    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
+    check( server );
+    int max_clients = 2;
+    netcode_server_start( server, max_clients );
+    context.server = server;
+
+    // connect a loopback client in slot 0
+
+    struct netcode_client_t * loopback_client = netcode_client_create_internal( "[::]:50000", time, network_simulator, NULL, NULL, NULL );
+    check( loopback_client );
+    netcode_client_connect_loopback( loopback_client, 0, max_clients );
+    netcode_client_send_loopback_packet_callback( loopback_client, &context, client_send_loopback_packet_callback );
+    context.client = loopback_client;
+
+    check( netcode_client_index( loopback_client ) == 0 );
+    check( netcode_client_loopback( loopback_client ) == 1 );
+    check( netcode_client_max_clients( loopback_client ) == max_clients );
+    check( netcode_client_state( loopback_client ) == NETCODE_CLIENT_STATE_CONNECTED );
+
+    uint64_t client_id = 0;
+    netcode_random_bytes( (uint8_t*) &client_id, 8 );
+
+    uint64_t skillz_match_id = 0;
+    netcode_random_bytes( (uint8_t*) &skillz_match_id, 8 );
+
+    netcode_server_connect_loopback_client( server, 0, client_id, skillz_match_id, NULL );
+
+    check( netcode_server_client_loopback( server, 0 ) == 1 );
+    check( netcode_server_client_connected( server, 0 ) == 1 );
+    check( netcode_server_num_connected_clients( server ) == 1 );
+
+    netcode_server_send_loopback_packet_callback( server, &context, server_send_loopback_packet_callback );
+
+    // connect a regular client in the other slot
+
+    struct netcode_client_t * regular_client = netcode_client_create_internal( "[::]:50001", time, network_simulator, NULL, NULL, NULL );
+
+    check( regular_client );
+
+    NETCODE_CONST char * server_address = "[::1]:40000";
+
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+    netcode_random_bytes( (uint8_t*) &client_id, 8 );
+    check( netcode_generate_connect_token( 1, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id,
+                                           skillz_match_id, TEST_PROTOCOL_ID, 0, private_key, connect_token ) );
+
+    netcode_client_connect( regular_client, connect_token );
+
+    while ( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        netcode_client_update( regular_client, time );
+
+        netcode_server_update( server, time );
+
+        if ( netcode_client_state( regular_client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        if ( netcode_client_state( regular_client ) == NETCODE_CLIENT_STATE_CONNECTED )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_client_state( regular_client ) == NETCODE_CLIENT_STATE_CONNECTED );
+    check( netcode_client_index( regular_client ) == 1 );
+    check( netcode_server_client_connected( server, 0 ) == 1 );
+    check( netcode_server_client_connected( server, 1 ) == 1 );
+    check( netcode_server_client_loopback( server, 0 ) == 1 );
+    check( netcode_server_client_loopback( server, 1 ) == 0 );
+    check( netcode_server_num_connected_clients( server ) == 2 );
+
+    // test that we can exchange packets for the regular client and the loopback client
+
+    int loopback_client_num_packets_received = 0;
+    int loopback_server_num_packets_received = 0;
+    int regular_server_num_packets_received = 0;
+    int regular_client_num_packets_received = 0;
+
+    uint8_t packet_data[NETCODE_MAX_PACKET_SIZE];
+    int i;
+    for ( i = 0; i < NETCODE_MAX_PACKET_SIZE; ++i )
+        packet_data[i] = (uint8_t) i;
+
+    while ( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        netcode_client_update( regular_client, time );
+
+        netcode_server_update( server, time );
+
+        netcode_client_send_packet( loopback_client, packet_data, NETCODE_MAX_PACKET_SIZE );
+
+        netcode_client_send_packet( regular_client, packet_data, NETCODE_MAX_PACKET_SIZE );
+
+        netcode_server_send_packet( server, 0, packet_data, NETCODE_MAX_PACKET_SIZE );
+
+        netcode_server_send_packet( server, 1, packet_data, NETCODE_MAX_PACKET_SIZE );
+
+        while ( 1 )
+        {
+            int packet_bytes;
+            uint64_t packet_sequence;
+            uint8_t * packet = netcode_client_receive_packet( loopback_client, &packet_bytes, &packet_sequence );
+            if ( !packet )
+                break;
+            (void) packet_sequence;
+            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
+            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
+            loopback_client_num_packets_received++;
+            netcode_client_free_packet( loopback_client, packet );
+        }
+
+        while ( 1 )
+        {
+            int packet_bytes;
+            uint64_t packet_sequence;
+            uint8_t * packet = netcode_client_receive_packet( regular_client, &packet_bytes, &packet_sequence );
+            if ( !packet )
+                break;
+            (void) packet_sequence;
+            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
+            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
+            regular_client_num_packets_received++;
+            netcode_client_free_packet( regular_client, packet );
+        }
+
+        while ( 1 )
+        {
+            int packet_bytes;
+            uint64_t packet_sequence;
+            void * packet = netcode_server_receive_packet( server, 0, &packet_bytes, &packet_sequence );
+            if ( !packet )
+                break;
+            (void) packet_sequence;
+            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
+            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
+            loopback_server_num_packets_received++;
+            netcode_server_free_packet( server, packet );
+        }
+
+        while ( 1 )
+        {
+            int packet_bytes;
+            uint64_t packet_sequence;
+            void * packet = netcode_server_receive_packet( server, 1, &packet_bytes, &packet_sequence );
+            if ( !packet )
+                break;
+            (void) packet_sequence;
+            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
+            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
+            regular_server_num_packets_received++;
+            netcode_server_free_packet( server, packet );
+        }
+
+        if ( loopback_client_num_packets_received >= 10 && loopback_server_num_packets_received >= 10 &&
+             regular_client_num_packets_received >= 10 && regular_server_num_packets_received >= 10 )
+            break;
+
+        if ( netcode_client_state( regular_client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        time += delta_time;
+    }
+
+    check( loopback_client_num_packets_received >= 10 );
+    check( loopback_server_num_packets_received >= 10 );
+    check( regular_client_num_packets_received >= 10 );
+    check( regular_server_num_packets_received >= 10 );
+    check( context.num_loopback_packets_sent_to_client >= 10 );
+    check( context.num_loopback_packets_sent_to_server >= 10 );
+
+    // verify that we can disconnect the loopback client
+
+    check( netcode_server_client_loopback( server, 0 ) == 1 );
+    check( netcode_server_client_connected( server, 0 ) == 1 );
+    check( netcode_server_num_connected_clients( server ) == 2 );
+
+    netcode_server_disconnect_loopback_client( server, 0 );
+
+    check( netcode_server_client_loopback( server, 0 ) == 0 );
+    check( netcode_server_client_connected( server, 0 ) == 0 );
+    check( netcode_server_num_connected_clients( server ) == 1 );
+
+    netcode_client_disconnect_loopback( loopback_client );
+
+    check( netcode_client_state( loopback_client ) == NETCODE_CLIENT_STATE_DISCONNECTED );
+
+    // verify that we can reconnect the loopback client
+
+    netcode_random_bytes( (uint8_t*) &client_id, 8 );
+    netcode_server_connect_loopback_client( server, 0, client_id, skillz_match_id, NULL );
+
+    check( netcode_server_client_loopback( server, 0 ) == 1 );
+    check( netcode_server_client_loopback( server, 1 ) == 0 );
+    check( netcode_server_client_connected( server, 0 ) == 1 );
+    check( netcode_server_client_connected( server, 1 ) == 1 );
+    check( netcode_server_num_connected_clients( server ) == 2 );
+
+    netcode_client_connect_loopback( loopback_client, 0, max_clients );
+
+    check( netcode_client_index( loopback_client ) == 0 );
+    check( netcode_client_loopback( loopback_client ) == 1 );
+    check( netcode_client_max_clients( loopback_client ) == max_clients );
+    check( netcode_client_state( loopback_client ) == NETCODE_CLIENT_STATE_CONNECTED );
+
+    // verify that we can exchange packets for both regular and loopback client post reconnect
+
+    loopback_server_num_packets_received = 0;
+    loopback_server_num_packets_received = 0;
+    regular_server_num_packets_received = 0;
+    regular_client_num_packets_received = 0;
+    context.num_loopback_packets_sent_to_client = 0;
+    context.num_loopback_packets_sent_to_server = 0;
+
+    while ( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        netcode_client_update( regular_client, time );
+
+        netcode_server_update( server, time );
+
+        netcode_client_send_packet( loopback_client, packet_data, NETCODE_MAX_PACKET_SIZE );
+
+        netcode_client_send_packet( regular_client, packet_data, NETCODE_MAX_PACKET_SIZE );
+
+        netcode_server_send_packet( server, 0, packet_data, NETCODE_MAX_PACKET_SIZE );
+
+        netcode_server_send_packet( server, 1, packet_data, NETCODE_MAX_PACKET_SIZE );
+
+        while ( 1 )
+        {
+            int packet_bytes;
+            uint64_t packet_sequence;
+            uint8_t * packet = netcode_client_receive_packet( loopback_client, &packet_bytes, &packet_sequence );
+            if ( !packet )
+                break;
+            (void) packet_sequence;
+            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
+            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
+            loopback_client_num_packets_received++;
+            netcode_client_free_packet( loopback_client, packet );
+        }
+
+        while ( 1 )
+        {
+            int packet_bytes;
+            uint64_t packet_sequence;
+            uint8_t * packet = netcode_client_receive_packet( regular_client, &packet_bytes, &packet_sequence );
+            if ( !packet )
+                break;
+            (void) packet_sequence;
+            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
+            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
+            regular_client_num_packets_received++;
+            netcode_client_free_packet( regular_client, packet );
+        }
+
+        while ( 1 )
+        {
+            int packet_bytes;
+            uint64_t packet_sequence;
+            void * packet = netcode_server_receive_packet( server, 0, &packet_bytes, &packet_sequence );
+            if ( !packet )
+                break;
+            (void) packet_sequence;
+            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
+            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
+            loopback_server_num_packets_received++;
+            netcode_server_free_packet( server, packet );
+        }
+
+        while ( 1 )
+        {
+            int packet_bytes;
+            uint64_t packet_sequence;
+            void * packet = netcode_server_receive_packet( server, 1, &packet_bytes, &packet_sequence );
+            if ( !packet )
+                break;
+            (void) packet_sequence;
+            netcode_assert( packet_bytes == NETCODE_MAX_PACKET_SIZE );
+            netcode_assert( memcmp( packet, packet_data, NETCODE_MAX_PACKET_SIZE ) == 0 );
+            regular_server_num_packets_received++;
+            netcode_server_free_packet( server, packet );
+        }
+
+        if ( loopback_client_num_packets_received >= 10 && loopback_server_num_packets_received >= 10 &&
+             regular_client_num_packets_received >= 10 && regular_server_num_packets_received >= 10 )
+            break;
+
+        if ( netcode_client_state( regular_client ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        time += delta_time;
+    }
+
+    check( loopback_client_num_packets_received >= 10 );
+    check( loopback_server_num_packets_received >= 10 );
+    check( regular_client_num_packets_received >= 10 );
+    check( regular_server_num_packets_received >= 10 );
+    check( context.num_loopback_packets_sent_to_client >= 10 );
+    check( context.num_loopback_packets_sent_to_server >= 10 );
+
+    // verify the regular client times out but loopback client doesn't
+
+    time += 100000.0;
+
+    netcode_server_update( server, time );
+
+    check( netcode_server_client_connected( server, 0 ) == 1 );
+    check( netcode_server_client_connected( server, 1 ) == 0 );
+
+    netcode_client_update( loopback_client, time );
+
+    check( netcode_client_state( loopback_client ) == NETCODE_CLIENT_STATE_CONNECTED );
+
+    // verify that disconnect all clients leaves loopback clients alone
+
+    netcode_server_disconnect_all_clients( server );
+
+    check( netcode_server_client_connected( server, 0 ) == 1 );
+    check( netcode_server_client_connected( server, 1 ) == 0 );
+    check( netcode_server_client_loopback( server, 0 ) == 1 );
+
+    // clean up
+
+    netcode_client_destroy( regular_client );
+
+    netcode_client_destroy( loopback_client );
+
+    netcode_server_destroy( server );
+
+    netcode_network_simulator_destroy( network_simulator );
+}
+
 //void test_skillz_add_two_clients_to_match()
 //{
 //    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
@@ -8283,17 +8334,17 @@ void netcode_test()
         RUN_TEST( test_client_server_keep_alive );
         RUN_TEST( test_client_server_multiple_clients );
         RUN_TEST( test_client_server_multiple_servers );
-        //RUN_TEST( test_client_error_connect_token_expired );
-        //RUN_TEST( test_client_error_invalid_connect_token );
-        //RUN_TEST( test_client_error_connection_timed_out );
-        //RUN_TEST( test_client_error_connection_response_timeout );
-        //RUN_TEST( test_client_error_connection_request_timeout );
-        //RUN_TEST( test_client_error_connection_denied );
-        //RUN_TEST( test_client_side_disconnect );
-        //RUN_TEST( test_server_side_disconnect );
-        //RUN_TEST( test_client_reconnect );
-        //RUN_TEST( test_disable_timeout );
-        //RUN_TEST( test_loopback );
+        RUN_TEST( test_client_error_connect_token_expired );
+        RUN_TEST( test_client_error_invalid_connect_token );
+        RUN_TEST( test_client_error_connection_timed_out );
+        RUN_TEST( test_client_error_connection_response_timeout );
+        RUN_TEST( test_client_error_connection_request_timeout );
+        RUN_TEST( test_client_error_connection_denied );
+        RUN_TEST( test_client_side_disconnect );
+        RUN_TEST( test_server_side_disconnect );
+        RUN_TEST( test_client_reconnect );
+        RUN_TEST( test_disable_timeout );
+        RUN_TEST( test_loopback );
         //RUN_TEST( test_skillz_add_two_clients_to_match );
         //RUN_TEST( test_skillz_only_two_clients_per_match_with_three_attempting );
         //RUN_TEST( test_skillz_disconnect_frees_one_match_then_the_other_with_four_clients );

--- a/netcode.c
+++ b/netcode.c
@@ -8018,7 +8018,7 @@ void test_skillz_add_two_clients_to_match()
         netcode_client_destroy( clients[i] );
     }
 
-    // Check if match was destroyed after disconnection.
+    // Check if match was removed and freed after disconnection.
     HASH_FIND_INT( server->skillz_matches, &match_id, match );
     check( match == NULL );
 
@@ -8082,12 +8082,138 @@ void test_skillz_only_two_clients_per_match_with_three_attempting()
     free( clients );
 }
 
-void test_skillz_disconnect_frees_match()
-{
-}
-
+// This test will need massive changes when we introduce removing matches based on dc time.
 void test_skillz_disconnect_frees_one_match_then_the_other_with_four_clients()
 {
+    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
+
+    network_simulator->latency_milliseconds = 250;
+    network_simulator->jitter_milliseconds = 250;
+    network_simulator->packet_loss_percent = 5;
+    network_simulator->duplicate_packet_percent = 10;
+
+    double time = 0.0;
+    double delta_time = 1.0 / 10.0;
+
+    int num_clients = 4;
+
+    struct netcode_server_t * server = netcode_server_create_internal("[::1]:40000", TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
+    check( server );
+    netcode_server_start( server, num_clients );
+
+    struct netcode_client_t ** clients = (struct netcode_client_t **) malloc( sizeof( struct netcode_client_t* ) * num_clients );
+    check(clients);
+
+    uint64_t token_sequence = 0;
+
+    // Client things.
+    for( int i = 0; i < num_clients; ++i )
+    {
+        char client_address[NETCODE_MAX_ADDRESS_STRING_LENGTH];
+        sprintf( client_address, "[::]:%d", 50000 + i );
+
+        *(clients + i) = netcode_client_create_internal( client_address, time, network_simulator, NULL, NULL, NULL );
+
+
+        check( clients[i] );
+
+        uint64_t client_id = i;
+        netcode_random_bytes( (uint8_t*) &client_id, 8 );
+
+        NETCODE_CONST char * server_address = "[::1]:40000";
+
+        uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+
+        check( netcode_generate_connect_token( 1,
+                                               &server_address,
+                                               TEST_CONNECT_TOKEN_EXPIRY,
+                                               TEST_TIMEOUT_SECONDS,
+                                               client_id,
+                                               TEST_PROTOCOL_ID,
+                                               token_sequence++,
+                                               private_key,
+                                               connect_token) );
+
+        netcode_client_connect( clients[i], connect_token );
+    }
+
+    // Connect the four clients.
+
+    while( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        for ( int j = 0; j < num_clients; ++j)
+        {
+            netcode_client_update( clients[j], time );
+        }
+
+        netcode_server_update( server, time );
+
+        int num_connected_clients = 0;
+
+        for( int j = 0; j < num_clients; ++j )
+        {
+            if( netcode_client_state( clients[j] ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+                break;
+
+            if( netcode_client_state( clients[j] ) == NETCODE_CLIENT_STATE_CONNECTED )
+                num_connected_clients++;
+        }
+
+        if ( num_connected_clients == num_clients )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_server_num_connected_clients( server ) == num_clients );
+
+    for( int j = 0; j < num_clients; ++j)
+    {
+        check( netcode_client_state( clients[j] ) == NETCODE_CLIENT_STATE_CONNECTED );
+        check( netcode_server_client_connected( server, j ) == 1 );
+    }
+
+    skillz_match_t * match;
+    int match1_id = 111;
+    int match2_id = 222;
+
+    // See if match1 exists, disconnect client one, then check if the match is gone while the
+    // other exists.
+    HASH_FIND_INT( server->skillz_matches, &match1_id, match );
+    check( match->skillz_match_id == match1_id );
+
+    netcode_server_disconnect_client( server, 0 );
+
+    HASH_FIND_INT( server->skillz_matches, &match1_id, match );
+    check( match == NULL);
+
+    // See if match2 exists, disconnect client three, then check if both of the matches are gone.
+    HASH_FIND_INT( server->skillz_matches, &match2_id, match );
+    check( match->skillz_match_id == match2_id );
+
+    netcode_server_disconnect_client(server, 2);
+
+    HASH_FIND_INT( server->skillz_matches, &match2_id, match );
+    check( match == NULL);
+
+
+    // Cleanup
+    netcode_server_disconnect_client( server, 1 );
+    netcode_server_disconnect_client( server, 3 );
+    for( int i = 0; i < num_clients; ++i )
+    {
+        netcode_client_destroy( clients[i] );
+    }
+
+    netcode_server_stop( server );
+    netcode_server_destroy( server );
+
+    netcode_network_simulator_destroy( network_simulator );
+
+    free( clients );
+
 }
 
 

--- a/netcode.c
+++ b/netcode.c
@@ -3491,13 +3491,13 @@ struct netcode_server_t
     int running;
     int max_clients;
     int num_connected_clients;
-    int max_clients_per_match;											/* Max clients per match */
+    int max_clients_per_match;
     uint64_t global_sequence;
     uint8_t private_key[NETCODE_KEY_BYTES];
     uint64_t challenge_sequence;
     uint8_t challenge_key[NETCODE_KEY_BYTES];
-    skillz_match_t * skillz_matches;									/* Matches hash table */
-    int skillz_match_id[NETCODE_MAX_CLIENTS];							/* Index using client_index, much like client_id */
+    skillz_match_t * skillz_matches;
+    int skillz_match_id[NETCODE_MAX_CLIENTS];
     int client_connected[NETCODE_MAX_CLIENTS];
     int client_timeout[NETCODE_MAX_CLIENTS];
     int client_loopback[NETCODE_MAX_CLIENTS];
@@ -3769,10 +3769,9 @@ void skillz_print_all_matches( struct netcode_server_t * server )
     skillz_match_t * match;
 
     netcode_printf( NETCODE_LOG_LEVEL_INFO, "\n\nPrinting the matches and their clients.\n" );
-    int i;
     for( match = server->skillz_matches; match != NULL; match = ( skillz_match_t * )( match->hh.next ) )
     {
-        for( i = 0; i < match->num_clients_in_match; ++i)
+        for( int i = 0; i < match->num_clients_in_match; ++i)
         {
             netcode_printf( NETCODE_LOG_LEVEL_INFO, "match id: %d client id: %d clients in match: %d\n",
                     match->skillz_match_id, match->clients_in_match[i], match->num_clients_in_match );
@@ -3821,7 +3820,6 @@ void netcode_server_disconnect_client_internal( struct netcode_server_t * server
     netcode_assert( client_index < server->max_clients );
     netcode_assert( server->client_connected[client_index] );
     netcode_assert( !server->client_loopback[client_index] );
-    //netcode_assert( server->skillz_matches );
 
     netcode_printf( NETCODE_LOG_LEVEL_INFO, "server disconnected client %d\n", client_index );
 
@@ -4206,12 +4204,16 @@ void netcode_server_connect_client( struct netcode_server_t * server,
 
     char address_string[NETCODE_MAX_ADDRESS_STRING_LENGTH];
 
-    /* TODO: try to find a way to deliver match itd. */
+    /* TODO: try to find a way to deliver match id. */
     int testId = 0;
     if( server->num_connected_clients >= 3 )
+    {
         testId = 222;
+    }
     else
+    {
         testId = 111;
+    }
     if ( !skillz_add_client_to_match( server, testId, client_id, client_index ) )
     {
         netcode_printf( NETCODE_LOG_LEVEL_ERROR, "failed to add client %d to match %d\n",

--- a/netcode.h
+++ b/netcode.h
@@ -105,8 +105,8 @@ typedef struct skillz_match_t
 {
     uint64_t 		skillz_match_id;		/* key */
     uint64_t 		clients_in_match[SKILLZ_MAX_CLIENTS_PER_MATCH];
-    int 			num_clients_in_match;
-    UT_hash_handle 	hh;						/* Makes this structure hashable!! */
+    int 		num_clients_in_match;
+    UT_hash_handle 	hh;				/* Makes this structure hashable!! */
 
 } skillz_match_t;
 

--- a/netcode.h
+++ b/netcode.h
@@ -99,7 +99,6 @@ extern "C" {
   **/
 
 #define SKILLZ_MAX_CLIENTS_PER_MATCH 2
-#define SKILLZ_MAX_MATCHES ( (int) (NETCODE_MAX_CLIENTS) / ( 2 ) )
 
 // SKILLZ_TOURNAMENT_T
 typedef struct skillz_match_t

--- a/netcode.h
+++ b/netcode.h
@@ -99,6 +99,7 @@ extern "C" {
   **/
 
 #define SKILLZ_MAX_CLIENTS_PER_MATCH 2
+#define SKILLZ_MAX_MATCHES ( (int) (NETCODE_MAX_CLIENTS) / ( 2 ) )
 
 // SKILLZ_TOURNAMENT_T
 typedef struct skillz_match_t

--- a/netcode.h
+++ b/netcode.h
@@ -55,7 +55,7 @@
 #define NETCODE_PLATFORM NETCODE_PLATFORM_UNIX
 #endif
 
-#define NETCODE_CONNECT_TOKEN_BYTES 2048
+#define NETCODE_CONNECT_TOKEN_BYTES (2048 + 8)
 #define NETCODE_KEY_BYTES 32
 #define NETCODE_MAC_BYTES 16
 #define NETCODE_MAX_SERVERS_PER_CONNECT 32
@@ -103,7 +103,7 @@ extern "C" {
 // SKILLZ_TOURNAMENT_T
 typedef struct skillz_match_t
 {
-    int 			skillz_match_id;		/* key */
+    uint64_t 		skillz_match_id;		/* key */
     uint64_t 		clients_in_match[SKILLZ_MAX_CLIENTS_PER_MATCH];
     int 			num_clients_in_match;
     UT_hash_handle 	hh;						/* Makes this structure hashable!! */
@@ -166,7 +166,8 @@ int netcode_generate_connect_token( int num_server_addresses,
                                     int expire_seconds,
                                     int timeout_seconds, 
                                     uint64_t client_id, 
-                                    uint64_t protocol_id, 
+                                    uint64_t skillz_match_id,
+                                    uint64_t protocol_id,
                                     uint64_t sequence, 
                                     NETCODE_CONST uint8_t * private_key, 
                                     uint8_t * connect_token );
@@ -215,7 +216,7 @@ void * netcode_server_client_user_data( struct netcode_server_t * server, int cl
 
 void netcode_server_connect_disconnect_callback( struct netcode_server_t * server, void * context, void (*callback_function)(void*,int,int) );
 
-void netcode_server_connect_loopback_client( struct netcode_server_t * server, int client_index, uint64_t client_id, NETCODE_CONST uint8_t * user_data );
+void netcode_server_connect_loopback_client( struct netcode_server_t * server, int client_index, uint64_t client_id, uint64_t skillz_match_id, NETCODE_CONST uint8_t * user_data );
 
 void netcode_server_disconnect_loopback_client( struct netcode_server_t * server, int client_index );
 


### PR DESCRIPTION
Packets are now created with a match id.  The hashtable's key is now a uint64_t instead of an int, for compatibility with TS.  All unit tests are passing.  Valgrind reports no additional errors.  cppcheck is clean.

@cchung89 first round
@kkaminski second round

Also no idea why the commits are going back for 2 days.  They're getting squashed anyways.

Also no clue why the formatting was changed on like every other line.

These changes were also pretty sweeping compared to the other ones.