### PR TITLE
[#151563071] Feature match expiration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,13 @@ Makefile
 *.7z
 *.zip
 *.tar.gz
+valgrind/*
+docker/*
+*.config
+*.creator
+*.files
+*.includes
+*.user
 
 # Sublime text
 *.sublime-project
@@ -36,10 +43,3 @@ c/valgrind/netcode.io
 docs
 *.exe
 
-valgrind/*
-docker/*
-
-*.config
-*.creator
-*.files
-*.includes

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ c/docker/netcode.io
 c/valgrind/netcode.io
 docs
 *.exe
+
+valgrind/*
+docker/*

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ docs
 
 valgrind/*
 docker/*
+
+*.config
+*.creator
+*.files
+*.includes

--- a/client.c
+++ b/client.c
@@ -79,9 +79,13 @@ int main( int argc, char ** argv )
     netcode_random_bytes( (uint8_t*) &client_id, 8 );
     printf( "client id is %.16" PRIx64 "\n", client_id );
 
+    /*
     uint64_t skillz_match_id = 0;
     netcode_random_bytes( (uint8_t*) &skillz_match_id, 8 );
     printf( "client is joining %" PRIu64 "\n", skillz_match_id );
+    */
+
+    uint64_t skillz_match_id = 111;
 
     uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
 

--- a/client.c
+++ b/client.c
@@ -79,12 +79,7 @@ int main( int argc, char ** argv )
     netcode_random_bytes( (uint8_t*) &client_id, 8 );
     printf( "client id is %.16" PRIx64 "\n", client_id );
 
-    /*
-    uint64_t skillz_match_id = 0;
-    netcode_random_bytes( (uint8_t*) &skillz_match_id, 8 );
-    printf( "client is joining %" PRIu64 "\n", skillz_match_id );
-    */
-
+    // TODO: make this not hardcoded.
     uint64_t skillz_match_id = 111;
 
     uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];

--- a/netcode.c
+++ b/netcode.c
@@ -5406,11 +5406,11 @@ static void test_address()
 
 #define TEST_PROTOCOL_ID            0x1122334455667788ULL
 #define TEST_CLIENT_ID              0x1ULL
-#define TEST_MATCH_ID			0x2ULL
+#define TEST_MATCH_ID		    0x2ULL
 #define TEST_SERVER_PORT            40000
 #define TEST_CONNECT_TOKEN_EXPIRY   30
 #define TEST_TIMEOUT_SECONDS        15
-#define TEST_MATCH_EXPIRE	1.0
+#define TEST_MATCH_EXPIRE	    1.0
 
 static void test_connect_token()
 {

--- a/netcode.c
+++ b/netcode.c
@@ -5410,11 +5410,11 @@ static void test_address()
 
 #define TEST_PROTOCOL_ID            0x1122334455667788ULL
 #define TEST_CLIENT_ID              0x1ULL
-#define TEST_MATCH_ID		    0x2ULL
+#define TEST_MATCH_ID               0x2ULL
 #define TEST_SERVER_PORT            40000
 #define TEST_CONNECT_TOKEN_EXPIRY   30
 #define TEST_TIMEOUT_SECONDS        15
-#define TEST_MATCH_EXPIRE	    1.0
+#define TEST_MATCH_EXPIRE           1.0
 
 static void test_connect_token()
 {

--- a/netcode.c
+++ b/netcode.c
@@ -4195,7 +4195,7 @@ int skillz_add_client_to_match(struct netcode_server_t * server, uint64_t skillz
         match->num_clients_in_match++;
         server->skillz_match_id[client_index] = skillz_match_id;
 
-        if( match->start_time == 0)
+        if( match->start_time == 0 )
             match->start_time = server->time;
         match->last_restart_time = server->time;
 
@@ -5410,7 +5410,7 @@ static void test_address()
 #define TEST_SERVER_PORT            40000
 #define TEST_CONNECT_TOKEN_EXPIRY   30
 #define TEST_TIMEOUT_SECONDS        15
-#define TEST_MATCH_EXPIRE		1.0
+#define TEST_MATCH_EXPIRE	1.0
 
 static void test_connect_token()
 {
@@ -8388,7 +8388,7 @@ void test_skillz_disconnect_one_match_then_the_other_with_four_clients()
     netcode_server_disconnect_client(server, 2);
 
     HASH_FIND( hh, server->skillz_matches, &match2_id, sizeof(uint64_t), match );
-    check( match->num_clients_in_match = prev_num_clients_in_match2 - 1);
+    check( match->num_clients_in_match = prev_num_clients_in_match2 - 1 );
 
 
     // Cleanup
@@ -8410,7 +8410,7 @@ void test_skillz_disconnect_one_match_then_the_other_with_four_clients()
 
 void test_match_expire()
 {
-    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL);
+    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
 
     network_simulator->latency_milliseconds = 250;
     network_simulator->jitter_milliseconds = 250;
@@ -8533,7 +8533,7 @@ void test_match_expire()
 
 void test_client_match_reconnection_within_window()
 {
-    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL);
+    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL );
 
     network_simulator->latency_milliseconds = 250;
     network_simulator->jitter_milliseconds = 250;

--- a/netcode.c
+++ b/netcode.c
@@ -4592,7 +4592,7 @@ void skillz_check_disconnected_matches( struct netcode_server_t * server )
         if( current_match->num_disconnects > 0 && current_match->num_clients_in_match < SKILLZ_MAX_CLIENTS_PER_MATCH )
         {
             uint64_t client_id = 0;
-            if( current_match->last_restart_time + current_match->max_disconnect_time >= server->time )
+            if( current_match->last_restart_time + current_match->max_disconnect_time <= server->time )
             {
                 int i;
                 for( i = 0; i < SKILLZ_MAX_CLIENTS_PER_MATCH; ++i )
@@ -8508,12 +8508,10 @@ void test_match_expire()
     check( match->num_clients_in_match == num_clients );
 
     netcode_server_disconnect_client( server, 0 );
-    time += 2.0;
+    time += 10.0;
     for( i = 0; i < num_clients; ++i )
         netcode_client_update( clients[i], time );
     netcode_server_update( server, time );
-
-    printf("%f\n", time);
 
     HASH_FIND( hh, server->skillz_matches, &skillz_match_id, sizeof(uint64_t), match );
     check( match == NULL );
@@ -8522,6 +8520,191 @@ void test_match_expire()
 
     for( i = 0; i < num_clients; ++i )
     {
+        netcode_client_destroy( clients[i] );
+    }
+
+    netcode_server_stop( server );
+    netcode_server_destroy( server );
+
+    netcode_network_simulator_destroy( network_simulator );
+
+    free( clients );
+}
+
+void test_client_match_reconnection_within_window()
+{
+    struct netcode_network_simulator_t * network_simulator = netcode_network_simulator_create( NULL, NULL, NULL);
+
+    network_simulator->latency_milliseconds = 250;
+    network_simulator->jitter_milliseconds = 250;
+    network_simulator->packet_loss_percent = 5;
+    network_simulator->duplicate_packet_percent = 10;
+
+    double time = 0.0;
+    double delta_time = 1.0 / 10.0;
+
+    int num_clients = 2;
+
+    struct netcode_server_t * server = netcode_server_create_internal( "[::1]:40000",  TEST_PROTOCOL_ID, private_key, time, network_simulator, NULL, NULL, NULL );
+    check( server );
+    netcode_server_start( server, num_clients );
+
+    struct netcode_client_t ** clients = (struct netcode_client_t **) malloc( sizeof( struct netcode_client_t*) * num_clients );
+    check( clients );
+
+    uint64_t token_sequence = 0;
+
+    uint64_t skillz_match_id = 0;
+    netcode_random_bytes( (uint8_t*) &skillz_match_id, 8 );
+
+    // Create and connect clients.
+    int i;
+    int j;
+    for( i = 0; i < num_clients; ++i )
+    {
+        char client_address[NETCODE_MAX_ADDRESS_STRING_LENGTH];
+        sprintf( client_address, "[::]:%d", 50000 + i );
+
+        clients[i] = netcode_client_create_internal( client_address, time, network_simulator, NULL, NULL, NULL );
+        check( clients[i] );
+
+        uint64_t client_id = i;
+        netcode_random_bytes( (uint8_t*) &client_id, 8 );
+
+        NETCODE_CONST char * server_address = "[::1]:40000";
+
+        uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+
+        check( netcode_generate_connect_token( 1,
+                                               &server_address,
+                                               TEST_CONNECT_TOKEN_EXPIRY,
+                                               TEST_TIMEOUT_SECONDS,
+                                               client_id,
+                                               skillz_match_id,
+                                               TEST_PROTOCOL_ID,
+                                               token_sequence++,
+                                               private_key,
+                                               connect_token) );
+
+        netcode_client_connect( clients[i], connect_token );
+    }
+
+    // Connect clients.
+
+    while( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        for( j = 0; j < num_clients; ++j )
+        {
+            netcode_client_update( clients[j], time );
+        }
+
+        netcode_server_update( server, time );
+
+        int num_connected_clients = 0;
+
+        for( j = 0; j < num_clients; ++j )
+        {
+            if( netcode_client_state( clients[j] ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+                break;
+
+            if( netcode_client_state( clients[j] ) == NETCODE_CLIENT_STATE_CONNECTED )
+                ++num_connected_clients;
+        }
+
+        if( num_connected_clients == num_clients )
+            break;
+
+        time += delta_time;
+    }
+
+    for( j = 0; j < num_clients; ++j )
+    {
+        check( netcode_client_state( clients[j] ) == NETCODE_CLIENT_STATE_CONNECTED );
+        check( netcode_server_client_connected( server, j ) == 1 );
+    }
+
+    skillz_match_t * match = NULL;
+    HASH_FIND( hh, server->skillz_matches, &skillz_match_id, sizeof(uint64_t), match );
+    check( match );
+    check( match->num_clients_in_match == num_clients );
+    int prev_num_clients_in_match = match->num_clients_in_match;
+
+    netcode_network_simulator_reset( network_simulator );
+
+    netcode_server_disconnect_client( server, 0 );
+
+    // Wait and check for disconnection.
+    while( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        for( i = 0; i < num_clients; ++i )
+            netcode_client_update( clients[i], time );
+
+        netcode_server_update( server, time );
+
+        if( netcode_client_state( clients[0] ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_client_state( clients[0] ) == NETCODE_CLIENT_STATE_DISCONNECTED );
+    check( netcode_server_client_connected( server, 0 ) == 0 );
+    check( netcode_server_num_connected_clients( server ) == 1 );
+
+    HASH_FIND( hh, server->skillz_matches, &skillz_match_id, sizeof(uint64_t), match );
+    check( match );
+    check( match->num_clients_in_match == prev_num_clients_in_match - 1 );
+
+    // reconnect, then check the match
+    netcode_network_simulator_reset( network_simulator );
+
+    NETCODE_CONST char * server_address = "[::1]:40000";
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+
+    check( netcode_generate_connect_token( 1,
+                                           &server_address,
+                                           TEST_CONNECT_TOKEN_EXPIRY,
+                                           TEST_TIMEOUT_SECONDS,
+                                           server->client_id[0],
+                                           skillz_match_id,
+                                           TEST_PROTOCOL_ID,
+                                           0,
+                                           private_key,
+                                           connect_token ) );
+
+    netcode_client_connect( clients[0], connect_token );
+
+    while( 1 )
+    {
+        netcode_network_simulator_update( network_simulator, time );
+
+        for( i = 0; i < num_clients; ++i )
+            netcode_client_update( clients[i], time );
+
+        netcode_server_update( server, time );
+
+        if( netcode_client_state( clients[0] ) <= NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+
+        if( netcode_client_state( clients[0] ) == NETCODE_CLIENT_STATE_CONNECTED )
+            break;
+
+        time += delta_time;
+    }
+
+    check( netcode_client_state( clients[0] ) == NETCODE_CLIENT_STATE_CONNECTED );
+
+    HASH_FIND( hh, server->skillz_matches, &skillz_match_id, sizeof(uint64_t), match );
+    check( match );
+    check( match->num_clients_in_match == prev_num_clients_in_match );
+
+    for( i = 0; i < num_clients; ++i )
+    {
+        netcode_server_disconnect_client( server, i );
         netcode_client_destroy( clients[i] );
     }
 
@@ -8580,6 +8763,7 @@ void netcode_test()
         RUN_TEST( test_skillz_only_two_clients_per_match_with_three_attempting );
         RUN_TEST( test_skillz_disconnect_one_match_then_the_other_with_four_clients );
         RUN_TEST( test_match_expire );
+        RUN_TEST( test_client_match_reconnection_within_window );
     }
 }
 

--- a/netcode.c
+++ b/netcode.c
@@ -5406,11 +5406,11 @@ static void test_address()
 
 #define TEST_PROTOCOL_ID            0x1122334455667788ULL
 #define TEST_CLIENT_ID              0x1ULL
-#define TEST_MATCH_ID		0x2ULL
+#define TEST_MATCH_ID			0x2ULL
 #define TEST_SERVER_PORT            40000
 #define TEST_CONNECT_TOKEN_EXPIRY   30
 #define TEST_TIMEOUT_SECONDS        15
-#define TEST_MATCH_EXPIRE	1.0
+#define TEST_MATCH_EXPIRE		1.0
 
 static void test_connect_token()
 {

--- a/netcode.c
+++ b/netcode.c
@@ -5406,11 +5406,11 @@ static void test_address()
 
 #define TEST_PROTOCOL_ID            0x1122334455667788ULL
 #define TEST_CLIENT_ID              0x1ULL
-#define TEST_MATCH_ID				0x2ULL
+#define TEST_MATCH_ID		0x2ULL
 #define TEST_SERVER_PORT            40000
 #define TEST_CONNECT_TOKEN_EXPIRY   30
 #define TEST_TIMEOUT_SECONDS        15
-#define TEST_MATCH_EXPIRE			1.0
+#define TEST_MATCH_EXPIRE	1.0
 
 static void test_connect_token()
 {
@@ -8333,7 +8333,7 @@ void test_skillz_disconnect_one_match_then_the_other_with_four_clients()
     {
         netcode_network_simulator_update( network_simulator, time );
 
-        for ( j = 0; j < num_clients; ++j)
+        for ( j = 0; j < num_clients; ++j )
         {
             netcode_client_update( clients[j], time );
         }

--- a/netcode.c
+++ b/netcode.c
@@ -4574,6 +4574,9 @@ void netcode_server_check_for_timeouts( struct netcode_server_t * server )
     }
 }
 
+// Disconnect a client and destroy a match if:
+// A client has disconnected, there are less than the max number of clients in the match,
+// and if the match has existed with a disconnect for longer than SKILLZ_MATCH_DISCONNECT_TIME.
 void skillz_check_disconnected_matches( struct netcode_server_t * server )
 {
     netcode_assert( server );
@@ -4585,7 +4588,7 @@ void skillz_check_disconnected_matches( struct netcode_server_t * server )
 
     HASH_ITER( hh, server->skillz_matches, current_match, tmp )
     {
-        if( current_match->num_disconnects > 0 )
+        if( current_match->num_disconnects > 0 && current_match->num_clients_in_match < SKILLZ_MAX_CLIENTS_PER_MATCH );
         {
             uint64_t client_id = 0;
             if( current_match->last_restart_time + current_match->max_disconnect_time >= server->time )

--- a/netcode.c
+++ b/netcode.c
@@ -3796,7 +3796,10 @@ void skillz_print_all_matches( struct netcode_server_t * server )
 /**
  * @brief skillz_match_delete
  * @param server
+ * @param match
  * @param client_index
+ *
+ * This function is only for freeing a match and removing its id from the list in server.
  */
 void skillz_match_free( struct netcode_server_t * server, skillz_match_t * match, int client_index )
 {
@@ -3811,7 +3814,7 @@ void skillz_match_free( struct netcode_server_t * server, skillz_match_t * match
  * @param client_index
  * @return bool if success.
  *
- * Removes the match from the hash table, frees the memeory.
+ * Removes a client from a match.  If no clients are in the match after removal, free the match.
  */
 int skillz_match_disconnect( struct netcode_server_t * server, int client_index )
 {
@@ -3833,6 +3836,7 @@ int skillz_match_disconnect( struct netcode_server_t * server, int client_index 
     netcode_assert( match->num_clients_in_match > 0 );
     ++match->num_disconnects;
     --match->num_clients_in_match;
+    server->skillz_match_id[client_index] = 0;
 
     if( match->num_clients_in_match <= 0 )
     {

--- a/netcode.h
+++ b/netcode.h
@@ -107,12 +107,12 @@ typedef struct skillz_match_t
 {
     uint64_t 		skillz_match_id;		/* key */
     uint64_t 		clients_in_match[SKILLZ_MAX_CLIENTS_PER_MATCH];
-    int 			num_clients_in_match;
-    int				max_num_disconnects;
-    int				num_disconnects;
-    double			max_disconnect_time;
-    double			start_time;
-    double			last_restart_time;
+    int 		num_clients_in_match;
+    int		max_num_disconnects;
+    int		num_disconnects;
+    double		max_disconnect_time;
+    double		start_time;
+    double		last_restart_time;
     UT_hash_handle 	hh;						/* Makes this structure hashable!! */
 
 } skillz_match_t;

--- a/netcode.h
+++ b/netcode.h
@@ -108,6 +108,7 @@ typedef struct skillz_match_t
     uint64_t 		skillz_match_id;		/* key */
     uint64_t 		clients_in_match[SKILLZ_MAX_CLIENTS_PER_MATCH];
     int 			num_clients_in_match;
+    int				max_num_disconnects;
     int				num_disconnects;
     double			max_disconnect_time;
     double			start_time;

--- a/netcode.h
+++ b/netcode.h
@@ -98,14 +98,20 @@ extern "C" {
   * Skillz Definitions
   **/
 
-#define SKILLZ_MAX_CLIENTS_PER_MATCH 2
+#define SKILLZ_MAX_CLIENTS_PER_MATCH 	2
+#define SKILLZ_MATCH_DISCONNECT_TIME 	10.0
+#define SKILLZ_MAX_MATCH_DISCONNECT		5
 
-// SKILLZ_TOURNAMENT_T
+// SKILLZ_MATCH_T: a struct for each match.
 typedef struct skillz_match_t
 {
     uint64_t 		skillz_match_id;		/* key */
     uint64_t 		clients_in_match[SKILLZ_MAX_CLIENTS_PER_MATCH];
-    int 		num_clients_in_match;
+    int 			num_clients_in_match;
+    int				num_disconnects;
+    double			max_disconnect_time;
+    double			start_time;
+    double			last_restart_time;
     UT_hash_handle 	hh;						/* Makes this structure hashable!! */
 
 } skillz_match_t;

--- a/netcode.h
+++ b/netcode.h
@@ -112,7 +112,7 @@ typedef struct skillz_match_t
     int		num_disconnects;
     double		max_disconnect_time;
     double		start_time;
-    double		last_restart_time;
+    double		last_client_connect_time;
     UT_hash_handle 	hh;						/* Makes this structure hashable!! */
 
 } skillz_match_t;

--- a/netcode.h
+++ b/netcode.h
@@ -100,7 +100,7 @@ extern "C" {
 
 #define SKILLZ_MAX_CLIENTS_PER_MATCH 	2
 #define SKILLZ_MATCH_DISCONNECT_TIME 	10.0
-#define SKILLZ_MAX_MATCH_DISCONNECT		5
+#define SKILLZ_MAX_MATCH_DISCONNECT	5
 
 // SKILLZ_MATCH_T: a struct for each match.
 typedef struct skillz_match_t


### PR DESCRIPTION
Summary of changes:

New variables in skillz_match_t to track max disconnect time and amount, match start, and last restart.  On connection these vars are initialized.  On a disconnect a client is now removed from the match, and the match persists.  In netcode_server_update a method has been added to sweep matches from the server.  This runs at n = # of connected matches.  So hopefully we don't have an obscene number of matches connected.  When a match has expired the client who was once connected gets disconnected from the server.

Passes valgrind and ccpcheck netcode.c --force

2 Tests added, to test if sweeping is successful and if re-connection is successful.  Also changed the behavior of a test to reflect these changes.

Passing when running 2 clients in the same match for disconnection and reconnection.  

@cchung89 First round
@kkaminski Second round